### PR TITLE
Add basic explanation of data formats inplace

### DIFF
--- a/views/parties.erb
+++ b/views/parties.erb
@@ -28,8 +28,16 @@
     <div class="page-section page-section--grey text-center">
         <div class="container" style="max-width: 26em;">
             <h3>Is this your data?</h3>
-            <p><strong>You can fix this problem</strong> by making sure your data is represented according to the Popolo standard. Blah blah blah blah, blah blah blah.</p>
-            <a href="#" class="button button--small">Find out more</a>
+            <p><strong>You can fix this</strong> by adding a <tt>classification</tt> of <tt>party</tt> to all relevant Organizations.</p>
+            <p>For example:
+            <p><pre>
+{
+      "name": "Centre Party",
+      "classification": "party",
+}
+
+            </pre></p>
+            <a href="/help/popolo" class="button button--small">Find out more</a>
         </div>
     </div>
 

--- a/views/people.erb
+++ b/views/people.erb
@@ -25,12 +25,4 @@
         </div>
     </div>
 
-    <div class="page-section page-section--grey text-center">
-        <div class="container" style="max-width: 26em;">
-            <h3>Is this your data?</h3>
-            <p><strong>You can fix this problem</strong> by making sure your data is represented according to the Popolo standard. Blah blah blah blah, blah blah blah.</p>
-            <a href="#" class="button button--small">Find out more</a>
-        </div>
-    </div>
-
 <% end %>

--- a/views/terms.erb
+++ b/views/terms.erb
@@ -28,8 +28,27 @@
     <div class="page-section page-section--grey text-center">
         <div class="container" style="max-width: 26em;">
             <h3>Is this your data?</h3>
-            <p><strong>You can fix this problem</strong> by making sure your data is represented according to the Popolo standard. Blah blah blah blah, blah blah blah.</p>
-            <a href="#" class="button button--small">Find out more</a>
+            <p><strong>You can fix this</strong> by adding a <tt>term</tt> list to the legislature. For example:</p>
+            <p><pre>
+{
+  "name": "Eduskunta",
+  "classification": "legislature",
+  "terms": [
+    {
+      "id": "term/35",
+      "name": "Eduskunta 35 (2007)",
+      "start_date": "2007-03-21",
+      "end_date": "2011-04-19",
+    },
+    {
+      "id": "term/36",
+      "name": "Eduskunta 36 (2011)",
+      "start_date": "2011-04-20",
+    }
+  ]
+}
+            </pre></p>
+            <a href="/help/popolo" class="button button--small">Find out more</a>
         </div>
     </div>
 


### PR DESCRIPTION
On the ‘parties’ and ‘terms’ pages, if we have nothing to show, give examples of how to structure your data.

(If we have no People, then there’s a much bigger problem!)

We still need to add the /help page that these link to (#14), and to style the <pre> sections better.

Closes #13 

