### PR TITLE
Issues/38 avatar list

### DIFF
--- a/views/area.erb
+++ b/views/area.erb
@@ -3,11 +3,14 @@
         <h1><%= @area['name'] %></h1>
 
       <% if @memberships %>
-        <ul>
+        <ul class="grid-list">
           <% @memberships.sort_by { |m| [m['end_date'] || '9999-99-99', m['start_date'] || '1111-11-11'] }.reverse.each do |m| %>
             <li>
-                <a href="<%= person_url(m['person']) %>"><%= m['person']['name'] %></a>
-                (<%= m['start_date'] %>–<%= m['end_date'] %>)
+                <a class="avatar-unit" href="<%= person_url(m['person']) %>">
+                    <span class="avatar"><i class="fa fa-user"></i></span>
+                    <h3><%= m['person']['name'] %></h3>
+                    <p><%= m['start_date'] %>–<%= m['end_date'] %></p>
+                </a>
             </li>
           <% end %>
         </ul>

--- a/views/front_index.erb
+++ b/views/front_index.erb
@@ -1,10 +1,17 @@
-<div class="container" id="home">
-    <h1>PopIt-Viewer</h1>
-    <p>This is a simple demo site for viewing PopIt data</p>
+<div class="page-section" id="home">
+    <div class="container">
+        <h1>PopIt-Viewer</h1>
+        <p>This is a simple demo site for viewing PopIt data</p>
 
-    <ul>
-      <% @countries.sort.each do |c| %>
-        <li><a href="/<%= c %>/"><%= c.capitalize %></a></li>
-      <% end %>
-    </ul>
+        <ul class="grid-list">
+          <% @countries.sort.each do |c| %>
+            <li>
+                <a class="avatar-unit" href="/<%= c %>/">
+                    <span class="avatar"><i class="fa fa-users"></i></span>
+                    <h3><%= c.capitalize %></h3>
+                </a>
+            </li>
+          <% end %>
+        </ul>
+    </div>
 </div>

--- a/views/parties.erb
+++ b/views/parties.erb
@@ -3,12 +3,12 @@
     <div class="page-section" id="parties">
         <div class="container">
             <h1>Parties</h1>
-            <ul class="avatar-list">
+            <ul class="grid-list">
               <% @parties.sort_by { |p| p['name'] }.each do |p| %>
                 <li>
-                    <a href="<%= party_url(p) %>">
+                    <a class="avatar-unit" href="<%= party_url(p) %>">
                         <span class="avatar"><i class="fa fa-users"></i></span>
-                        <span class="label"><%= p['name'] %></span>
+                        <h3><%= p['name'] %></h3>
                     </a>
                 </li>
               <% end %>

--- a/views/party.erb
+++ b/views/party.erb
@@ -4,12 +4,12 @@
 
       <% if @memberships %>
         <h3>Members</h3>
-        <ul class="avatar-list">
+        <ul class="grid-list">
           <% @memberships.each do |m| %>
             <li>
-                <a href="<%= person_url(m['person']) %>">
+                <a class="avatar-unit" href="<%= person_url(m['person']) %>">
                     <span class="avatar"><i class="fa fa-user"></i></span>
-                    <span class="label"><%= m['person']['name'] %></span>
+                    <h3><%= m['person']['name'] %></h3>
                 </a>
             </li>
           <% end %>

--- a/views/people.erb
+++ b/views/people.erb
@@ -3,12 +3,12 @@
     <div class="page-section" id="people">
         <div class="container">
             <h1>People</h1>
-            <ul class="avatar-list">
+            <ul class="grid-list">
               <% @people.sort_by { |p| p['name'] }.each do |p| %>
                 <li>
-                    <a href="<%= person_url(p) %>">
+                    <a class="avatar-unit" href="<%= person_url(p) %>">
                         <span class="avatar"><i class="fa fa-user"></i></span>
-                        <span class="label"><%= p['name'] %></span>
+                        <h3><%= p['name'] %></h3>
                     </a>
                 </li>
               <% end %>

--- a/views/sass/_components.scss
+++ b/views/sass/_components.scss
@@ -260,7 +260,15 @@ p.lead {
     @extend .unstyled-list;
   
     & > * {
-        @include flex(1 0 20em);
+        @include flex(0 0 100%);
+
+        @media (min-width: $medium_screen) {
+          @include flex(0 0 50%);
+        }
+
+        @media (min-width: $medium_screen * 1.5) {
+          @include flex(0 0 33%);
+        }
     }
 }
 

--- a/views/sass/_components.scss
+++ b/views/sass/_components.scss
@@ -253,36 +253,38 @@ p.lead {
     border-color: mix(#fff, $colour_red, 40%);
 }
 
-.avatar-list {
+.grid-list {
+    @include flexbox();
+    @include flex-align(center);
+    @include flex-wrap(wrap);
     @extend .unstyled-list;
-    @include vendor-prefix('column-width', 20em);
-    @include vendor-prefix('column-gap', 2em);
+  
+    & > * {
+        @include flex(1 0 20em);
+    }
+}
 
-    a {
-        display: block;
-        padding: 0.5em 0;
-        color: inherit;
-        overflow: hidden;
-        white-space: nowrap;
-        text-overflow: ellipsis;
+.avatar-unit {
+    display: block;
+    color: inherit;
+    position: relative;
+    padding: 0.5em 0.5em 0.5em 3em;
+    margin-bottom: 0.5em;
 
-        &:hover,
-        &:focus {
-            .avatar {
-                background: darken($colour_green, 5%);
-            }
-            .label {
-                text-decoration: underline;
-            }
-        }
+    & > * {
+        margin: 0;
+        line-height: 1.2em;
     }
 
     .avatar {
-        display: inline-block;
-        text-align: center;
-        width: 2em;
+        display: block;
         height: 2em;
-        margin-right: 0.5em;
+        width: 2em;
+        text-align: center;
+        position: absolute;
+        top: 50%;
+        left: 0;
+        margin-top: -1em;
         background: $colour_green;
         border-radius: 1em;
 
@@ -292,8 +294,16 @@ p.lead {
             text-shadow: 0 1px 0 rgba(0,0,0,0.2);
         }
     }
-
-    .label {
-        line-height: 2em;
+    
+    h3 {
+        font-weight: 500;
+        
+        & + p {
+            margin-bottom: 0.2em;
+        }
+    }
+    
+    p {
+        opacity: 0.5;
     }
 }

--- a/views/sass/_mixins.scss
+++ b/views/sass/_mixins.scss
@@ -35,6 +35,35 @@
     border-top-left-radius: $radius;
 }
 
+@mixin flexbox() {
+  display: -webkit-box;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  display: flex;
+}
+
+@mixin flex($values) {
+  -webkit-box-flex: $values;
+  -moz-box-flex: $values;
+  -webkit-flex: $values;
+  -ms-flex: $values;
+  flex: $values;
+}
+
+@mixin flex-align($alignment) {
+  -webkit-box-align: $alignment;
+  -webkit-align-items: $alignment;
+  -ms-flex-align: $alignment;
+  align-items: $alignment;
+}
+
+@mixin flex-wrap($wrap) {
+  -moz-box-wrap: $wrap;
+  -webkit-box-wrap: $wrap;
+  -ms-flexbox-wrap: $wrap;
+  flex-wrap: $wrap;
+}
 
 .image-replacement {
     overflow: hidden;

--- a/views/sass/_site-header.scss
+++ b/views/sass/_site-header.scss
@@ -46,7 +46,7 @@
     @media (min-width: $large_screen) {
         position: absolute;
         left: 36px;
-        top: 23px;
+        top: 3px;
         float: none;
         text-align: center;
         margin: 0;

--- a/views/styling.erb
+++ b/views/styling.erb
@@ -16,7 +16,8 @@
                     <li><a href="#vertical-spacing">Vertical spacing</a></li>
                     <li><a href="#hero-sections">Hero sections</a></li>
                     <li><a href="#buttons">Buttons</a></li>
-                    <li><a href="#advanced-lists">Lists of things</a></li>
+                    <li><a href="#grids">Grids of things</a></li>
+                    <li><a href="#avatar-units">Avatar units</a></li>
                     <li><a href="#basic-lists">Unstyled and inline lists</a></li>
                     <li><a href="#alerts">Alerts</a></li>
                 </ul>
@@ -134,37 +135,58 @@
 
                 <hr>
 
-                <h1 id="advanced-lists">Lists of things</h1>
+                <h1 id="grids">Grids of things</h1>
 
-                <p>The <code>.avatar-list</code> is ideal for displaying lists of people, places, or things:</p>
+                <p>The <code>.grid-list</code> is ideal for displaying lists of people, places, or things (especially when combined with <code>.avatar-unit</code>):</p>
 
-                <ul class="avatar-list">
+                <ul class="grid-list">
                   <% @names = [ 'Tony Stark', 'Obadiah Stane', 'Pepper Potts', 'Justin Hammer', 'Nick Fury', 'Jim Rhodes' ] %>
                   <% @names.each do |name| %>
                     <li>
-                        <a href="#">
+                        <a class="avatar-unit" href="#">
                             <span class="avatar"><i class="fa fa-user"></i></span>
-                            <span class="label"><%= name %></span>
+                            <h3><%= name %></h3>
                         </a>
                     </li>
                   <% end %>
                 </ul>
 
                 <pre>
-&lt;ul class="avatar-list"&gt;
+&lt;ul class="grid-list"&gt;
     &lt;li&gt;
-        &lt;a href="#"&gt;
+        &lt;a class="avatar-unit" href="#"&gt;
             &lt;span class="avatar"&gt;&lt;i class="fa fa-user"&gt;&lt;/i&gt;&lt;/span&gt;
-            &lt;span class="label"&gt;Tony Stark&lt;/span&gt;
+            &lt;h3&gt;Tony Stark&lt;/h3&gt;
         &lt;/a&gt;
     &lt;/li&gt;
     …
 &lt;/ul&gt;</pre>
 
-                <p><strong>Note:</strong> In modern browsers, the list will break into as many columns as will fit on the screen. Old browsers will get a single column.</p>
+                <p><strong>Note:</strong> In modern browsers and Internet Explorer 10+, the list will break into as many columns as will fit on the screen. Older browsers will see a single column. <a href="http://caniuse.com/#search=flex">Show full browser compatibility table.</a></p>
+
+                <hr>
+                
+                <h1 id="avatar-units">Avatar units</h1>
+                  
+                <p>Avatar units provide a simple way of displaying the name of a thing along with an icon representing it and, optionally, some extra information like a date or location:</p>
+                
+                <a class="avatar-unit" href="#">
+                    <span class="avatar"><i class="fa fa-user"></i></span>
+                    <h3>Tony Stark</h3>
+                    <p>CEO, Stark Industries</p>
+                </a>
+                
+                <pre>
+&lt;a class="avatar-unit" href="#"&gt;
+    &lt;span class="avatar"&gt;&lt;i class="fa fa-user"&gt;&lt;/i&gt;&lt;/span&gt;
+    &lt;h3&gt;Tony Stark&lt;/h3&gt;
+    &lt;p&gt;CEO, Stark Industries&lt;/p&gt;
+&lt;/a&gt;</pre>
+                
+                <p>Avatar units must contain a <code>&lt;span class="avatar"&gt;</code> element, but all other content is optional. When combined with <code>.grid-list</code>, above, Avatar units of different heights will be vertically aligned along their common centre.</p>
 
                 <p>You can change the icon displayed by replacing <code>&lt;i class="fa fa-user"&gt;</code> with one of the icon codes from the <a href="http://fortawesome.github.io/Font-Awesome/icons/">Font Awesome docs</a>.</p>
-
+                
                 <hr>
 
                 <h1 id="basic-lists">Unstyled and inline lists</h1>

--- a/views/term.erb
+++ b/views/term.erb
@@ -4,14 +4,14 @@
         <p><%= @term['start_date'] %> – <%= @term['end_date'] %></p>
 
       <% if @memberships %>
-        <ul class="avatar-list">
+        <ul class="grid-list">
           <% @memberships.sort_by { |m| m['person']['name'] }.each do |m| %>
             <li>
-               <a href="<%= person_url(m['person']) %>">
-                 <span class="avatar"><i class="fa fa-user"></i></span>
-                 <span class="label"><%= m['person']['name'] %></span>
+               <a class="avatar-unit" href="<%= person_url(m['person']) %>">
+                   <span class="avatar"><i class="fa fa-user"></i></span>
+                   <h3><%= m['person']['name'] %></h3>
+                   <p><%= m['start_date'] %>–<%= m['end_date'] %></p>
                </a>
-               (<%= m['start_date'] %>–<%= m['end_date'] %>)
             </li>
           <% end %>
         </ul>

--- a/views/terms.erb
+++ b/views/terms.erb
@@ -3,12 +3,12 @@
     <div class="page-section" id="terms">
         <div class="container">
             <h1>Terms</h1>
-            <ul class="avatar-list">
+            <ul class="grid-list">
               <% @terms.sort_by { |t| t['start_date'] }.reverse.each do |t| %>
                 <li>
-                    <a href="<%= term_url(t) %>">
+                    <a class="avatar-unit" href="<%= term_url(t) %>">
                         <span class="avatar"><i class="fa fa-university"></i></span>
-                        <span class="label"><%= t['name'] %></span>
+                        <h3><%= t['name'] %></h3>
                     </a>
                 </li>
               <% end %>


### PR DESCRIPTION
Fixes #38.

`.avatar-list` has now become `.grid-list` and `.avatar-unit`. The first handles the display of an awesome automatic grid which vertically centres its cells so you don't have to worry about extra content in one cell knocking off the layout of all the others.

`.avatar-unit` replicates the actual layout of a person's name and avatar, as before, but also allows for paragraphs of information under the person's name.

![screen shot 2015-04-22 at 12 02 08](https://cloud.githubusercontent.com/assets/739624/7273018/a26cc0c4-e8e7-11e4-849a-4c9a2e9b4c8c.png)
