### PR TITLE
Only show dates for memberships if they don't match the term.

### DIFF
--- a/t/web/eduskunta.rb
+++ b/t/web/eduskunta.rb
@@ -97,10 +97,18 @@ describe "Stance viewer" do
 
   describe "when viewing an Term page" do
 
-    before { get '/FI/term/27' }
+    before { get '/FI/term/28' }
 
     it "should have have its name" do
-      subject.css('h1').text.must_equal 'Eduskunta 27 (1975 II)'
+      subject.css('h1').text.must_equal 'Eduskunta 28 (1979)'
+    end
+
+    it "shouldn't show matching term dates" do
+      subject.css('a[href*="103"]').text.wont_include '1979'
+    end
+
+    it "should show non matching term dates" do
+      subject.css('a[href*="311"]').text.must_include '1979'
     end
 
   end

--- a/views/term.erb
+++ b/views/term.erb
@@ -10,7 +10,9 @@
                <a class="avatar-unit" href="<%= person_url(m['person']) %>">
                    <span class="avatar"><i class="fa fa-user"></i></span>
                    <h3><%= m['person']['name'] %></h3>
-                   <p><%= m['start_date'] %>–<%= m['end_date'] %></p>
+                   <% if m['start_date'] != @term['start_date'] or m['end_date'] != @term['end_date'] %>
+                     <p><%= m['start_date'] %>–<%= m['end_date'] %></p>
+                   <% end %>
                </a>
             </li>
           <% end %>


### PR DESCRIPTION
On the term page, only show dates for a membership if those differ from the dates of the term.

Fixes #34