### PR TITLE
Sinatra routes

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -13,6 +13,9 @@ mapping = {
 }
 
 before '/:country/*' do |country, _|
+  # Allow inbuilt sinatra requests through
+  pass if country == '__sinatra__'
+
   found = mapping.find { |fn, codes| codes.include? country.downcase } or
     halt 404
   @country = found.last.first

--- a/data/greenland/incoming/2013-03-12-gov.csv
+++ b/data/greenland/incoming/2013-03-12-gov.csv
@@ -1,0 +1,9 @@
+name,image,party,executive,email,term
+Aleqa Hammond,/media/760992/Aleqa_Hammond.jpg,Siumut,The Premier,alha@inatsisartut.gl,2013-03-12
+Finn Karlsen,/media/234423/2010.09.17 Start EM 2010 00928.jpg,Siumut,Member of Naalakkersuisut,fika@nanoq.gl,2013-03-12
+Jens-Erik Kirkegaard,/media/761460/Jens_Erik_Kirkegaard.jpg,Siumut,Member of Naalakkersuisut,jenserik@inatsisartut.gl,2013-03-12
+Kim Kielsen,/media/234524/2010.09.17 Start EM 2010 00953.jpg,Siumut,Member of Naalakkersuisut,kim@nanoq.gl,2013-03-12
+Martha Lund Olsen,/media/759167/Martha_Lund_Olsen.bmp,Siumut,Member of Naalakkersuisut,mlol@nanoq.gl,2013-03-12
+Nick Nielsen,/media/759491/Nick_Nielsen.jpg,Siumut,Member of Naalakkersuisut,nick@nanoq.gl,2013-03-12
+Siverth Karl Heilmann,/media/234533/2010.09.17 Start EM 2010 00891.jpg,Atassut,Member of Inatsisartut,skhe@inatsisartut.gl,2013-03-12
+Vittus Qujaukitsoq,/media/762216/Vittus_Qujaukitsoq.jpg,Siumut,Member of Naalakkersuisut,viqu@nanoq.gl,2013-03-12

--- a/data/greenland/incoming/2013-03-12-parl.csv
+++ b/data/greenland/incoming/2013-03-12-parl.csv
@@ -1,0 +1,30 @@
+name,image,party,status,email,term
+Lars-Emil Johansen,/media/753863/Lars-Emil Johansen - 07533.jpg,Siumut,President of Inatsisartut,larsemil@inatsisartut.gl,2013-03-12
+Aleqa Hammond,/media/760992/Aleqa_Hammond.jpg,Siumut,The Premier,alha@inatsisartut.gl,2013-03-12
+Agathe Fontain,/media/234537/2010.09.17 Start EM 2010 00896.jpg,Inuit Ataqatigiit,Member of Inatsisartut,agathe@inatsisartut.gl,2013-03-12
+Anders Olsen,/media/293529/untitled-4.jpg,Siumut,Member of Inatsisartut,anols@inatsisartut.gl,2013-03-12
+Andreas Uldum,/media/234534/2010.09.17 Start EM 2010 00892.jpg,Demokraatiit,Member of Inatsisartut,uldum@nanoq.gl,2013-03-12
+Ane Hansen,/media/234538/2010.09.17 Start EM 2010 00903.jpg,Inuit Ataqatigiit,Member of Inatsisartut,aneh@inatsisartut.gl,2013-03-12
+Aqqaluaq B. Egede,/media/234438/2010.09.17 Start EM 2010 00886.jpg,Inuit Ataqatigiit,Member of Inatsisartut,aqqe@inatsisartut.gl,2013-03-12
+Astrid Fleischer Rex,/media/234413/2010.09.17 Start EM 2010 00912.jpg,Inuit Ataqatigiit,Member of Inatsisartut,asfl@inatsisartut.gl,2013-03-12
+Doris Jakobsen,/media/293877/untitled-5.jpg,Siumut,Member of Inatsisartut,doja@nanoq.gl,2013-03-12
+Evelyn Frederiksen,/media/753489/Evelyn Frederiksen - 07654.jpg,Siumut,Member of Inatsisartut,evelyn@inatsisartut.gl,2013-03-12
+Hans Enoksen,/media/298458/untitled-6.jpg,Partii Naleraq,Member of Inatsisartut,hans@inatsisartut.gl,2013-03-12
+Hans Aronsen,/media/234453/2010.09.17 Start EM 2010 00900.jpg,Inuit Ataqatigiit,Member of Inatsisartut,haar@inatsisartut.gl,2013-03-12
+Harald Bianco,/media/234500/2010.09.17 Start EM 2010 00904.jpg,Inuit Ataqatigiit,Member of Inatsisartut,habi@inatsisartut.gl,2013-03-12
+Jens Immanuelsen,/media/402739/Jens Immanuelsen - 03714.jpg,Siumut,Member of Inatsisartut,jeim@inatsisartut.gl,2013-03-12
+Juliane Henningsen,/media/234488/2010.09.17 Start EM 2010 00898.jpg,Inuit Ataqatigiit,Member of Inatsisartut,jhen@inatsisartut.gl,2013-03-12
+Kalistat Lund,/media/719177/Kalistat Lund - 07662.jpg,Inuit Ataqatigiit,Member of Inatsisartut,kalistat@inatsisartut.gl,2013-03-12
+Karl Lyberth,/media/762432/Karl_Lyberth.jpg,Siumut,Member of Inatsisartut,karll@inatsisartut.gl,2013-03-12
+Karl-Kristian Kruse,/media/719211/Karl-Kristian Kruse - 07672.jpg,Siumut,Member of Inatsisartut,kkkr@nanoq.gl,2013-03-12
+Kristian Jeremiassen,/media/234527/2010.09.17 Start EM 2010 00926.jpg,Siumut,Member of Inatsisartut,krje@inatsisartut.gl,2013-03-12
+Lars Mathæussen,/media/752555/Lars Mathaeussen - 07657.jpg,Siumut,Member of Inatsisartut,lars@inatsisartut.gl,2013-03-12
+Michael Rosing,/media/530703/Michael Rosing - 01220.jpg,Demokraatiit,Member of Inatsisartut,michael@inatsisartut.gl,2013-03-12
+Mimi Karlsen,/media/234447/2010.09.17 Start EM 2010 00909.jpg,Inuit Ataqatigiit,Member of Inatsisartut,mimi@inatsisartut.gl,2013-03-12
+Naaja H. Nathanielsen,/media/234421/2010.09.17 Start EM 2010 00941.jpg,Inuit Ataqatigiit,Member of Inatsisartut,nana@inatsisartut.gl,2013-03-12
+Nikolaj Jeremiassen,/media/719823/Nikolaj Jeremiassen - 07666.jpg,Siumut,Member of Inatsisartut,nije@inatsisartut.gl,2013-03-12
+Per Berthelsen,/media/234529/2010.09.17 Start EM 2010 00930.jpg,Siumut,Member of Inatsisartut,pebe@inatsisartut.gl,2013-03-12
+Randi Broberg,/media/720187/Randi Broberg - 07671.jpg,Partii Inuit,Member of Inatsisartut,randi@inatsisartut.gl,2013-03-12
+Ruth Heilmann,/media/234528/2010.09.17 Start EM 2010 00940.jpg,Siumut,Member of Inatsisartut,ruth@inatsisartut.gl,2013-03-12
+Sara Olsvig,/media/720255/Sara Olsvig - 07669.jpg,Inuit Ataqatigiit,Member of Inatsisartut,saol@inatsisartut.gl,2013-03-12
+Siverth Karl Heilmann,/media/234533/2010.09.17 Start EM 2010 00891.jpg,Atassut,Member of Inatsisartut,skhe@inatsisartut.gl,2013-03-12

--- a/data/greenland/incoming/2014-11-28-parl.csv
+++ b/data/greenland/incoming/2014-11-28-parl.csv
@@ -1,0 +1,32 @@
+name,image,party,status,email,term
+Suka K. Frederiksen,/media/2461297/Suka K. Frederiksen 2014.12 - 15510.jpg,Siumut,Member of Inatsisartut,suka@inatsisartut.gl,2014-11-28
+Jens Immanuelsen,/media/402739/Jens Immanuelsen - 03714.jpg,Siumut,Member of Inatsisartut,jeim@inatsisartut.gl,2014-11-28
+Aaja Chemnitz Larsen,/media/2461849/Aaja Chemnitz Larsen 2014.12 - 15537.jpg,Inuit Ataqatigiit,Member of Inatsisartut,aacl@inatsisartut.gl,2014-11-28
+Agathe Fontain,/media/234537/2010.09.17 Start EM 2010 00896.jpg,Inuit Ataqatigiit,Member of Inatsisartut,agathe@inatsisartut.gl,2014-11-28
+Anders Olsen,/media/293529/untitled-4.jpg,Siumut,Member of Inatsisartut,anols@inatsisartut.gl,2014-11-28
+Andreas Uldum,/media/234534/2010.09.17 Start EM 2010 00892.jpg,Demokraatit,Member of Inatsisartut,uldum@nanoq.gl,2014-11-28
+Ane Hansen,/media/234538/2010.09.17 Start EM 2010 00903.jpg,Inuit Ataqatigiit,Member of Inatsisartut,aneh@inatsisartut.gl,2014-11-28
+Anthon Frederiksen,/media/234539/2010.09.17 Start EM 2010 00946.jpg,Partii Naleraq,Member of Inatsisartut,antuut@inatsisartut.gl,2014-11-28
+Aqqaluaq B. Egede,/media/234438/2010.09.17 Start EM 2010 00886.jpg,Inuit Ataqatigiit,Member of Inatsisartut,aqqe@inatsisartut.gl,2014-11-28
+Doris Jakobsen,/media/293877/untitled-5.jpg,Siumut,Member of Inatsisartut,doja@nanoq.gl,2014-11-28
+Hans Enoksen,/media/298458/untitled-6.jpg,Partii Naleraq,Member of Inatsisartut,hans@inatsisartut.gl,2014-11-28
+Iddimanngiiu Bianco,/media/2461401/Iddimanngiiu Bianco 2014.12 - 15527.jpg,Inuit Ataqatigiit,Member of Inatsisartut,idjb@inatsisartut.gl,2014-11-28
+Ineqi Kielsen,/media/2461245/Ineqi Kielsen 2014.12 - 15542.jpg,Siumut,Member of Inatsisartut,ineqi@inatsisartut.gl,2014-11-28
+Juliane Henningsen,/media/234488/2010.09.17 Start EM 2010 00898.jpg,Inuit Ataqatigiit,Member of Inatsisartut,jhen@inatsisartut.gl,2014-11-28
+Justus Hansen,/media/234516/2010.09.17 Start EM 2010 00888.jpg,Demokraatit,Member of Inatsisartut,justus@inatsisartut.gl,2014-11-28
+Kalistat Lund,/media/719177/Kalistat Lund - 07662.jpg,Inuit Ataqatigiit,Member of Inatsisartut,kalistat@inatsisartut.gl,2014-11-28
+Karl-Kristian Kruse,/media/719211/Karl-Kristian Kruse - 07672.jpg,Siumut,Member of Inatsisartut,kkkr@nanoq.gl,2014-11-28
+Kim Kielsen,/media/234524/2010.09.17 Start EM 2010 00953.jpg,Siumut,Member of Inatsisartut,kim@nanoq.gl,2014-11-28
+Knud Kristiansen,/media/234532/2010.09.17 Start EM 2010 00916.jpg,Atassut,Member of Inatsisartut,knkr@nanoq.gl ,2014-11-28
+Lars-Emil Johansen,/media/753863/Lars-Emil Johansen - 07533.jpg,Siumut,Member of Inatsisartut,larsemil@inatsisartut.gl,2014-11-28
+Laura Tàunâjik,/media/2461193/Laura Taunajik 2014.12 - 15533.jpg,Siumut,Member of Inatsisartut,laura@inatsisartut.gl,2014-11-28
+Mala  Høy Kuko,/media/2448262/INAT-dukke-lys.jpg,Atassut,Member of Inatsisartut,,2014-11-28
+Martha Lund Olsen,/media/759167/Martha_Lund_Olsen.bmp,Siumut,Member of Inatsisartut,mlol@nanoq.gl,2014-11-28
+Mimi Karlsen,/media/234447/2010.09.17 Start EM 2010 00909.jpg,Inuit Ataqatigiit,Member of Inatsisartut,mimi@inatsisartut.gl,2014-11-28
+Naaja H. Nathanielsen,/media/234421/2010.09.17 Start EM 2010 00941.jpg,Inuit Ataqatigiit,Member of Inatsisartut,nana@inatsisartut.gl,2014-11-28
+Nikolaj Jeremiassen,/media/719823/Nikolaj Jeremiassen - 07666.jpg,Siumut,Member of Inatsisartut,nije@inatsisartut.gl,2014-11-28
+Nivi  Olsen,/media/2448458/INAT-dukke-lys.jpg,Demokraatit,Member of Inatsisartut,nivi@nanoq.gl,2014-11-28
+Per Rosing-Petersen,/media/2461609/Per Rosing Petersen 2014.12 - 15506.jpg,Partii Naleraq,Member of Inatsisartut,perrp@inatsisartut.gl,2014-11-28
+Peter Olsen,/media/2462571/Peter Olsen 2014.12 - 15521.jpg,Inuit Ataqatigiit,Member of Inatsisartut,ppol@inatsisartut.gl,2014-11-28
+Randi Vestergaard Evaldsen,/media/2462756/Randi Vestergaard Evaldsen 2014.12 - 15505.jpg,Demokraatit,Member of Inatsisartut,rave@inatsisartut.gl,2014-11-28
+Sara Olsvig,/media/720255/Sara Olsvig - 07669.jpg,Inuit Ataqatigiit,Member of Inatsisartut,saol@inatsisartut.gl,2014-11-28

--- a/data/greenland/incoming/2014-12-12-gov.csv
+++ b/data/greenland/incoming/2014-12-12-gov.csv
@@ -1,0 +1,9 @@
+name,image,party,executive,email,term
+Andreas Uldum,/media/234534/2010.09.17 Start EM 2010 00892.jpg,Demokraatit,Deputy-Premier,uldum@nanoq.gl,2014-12-12
+Karl-Kristian Kruse,/media/719211/Karl-Kristian Kruse - 07672.jpg,Siumut,Member of Naalakkersuisut,kkkr@nanoq.gl,2014-12-12
+Kim Kielsen,/media/234524/2010.09.17 Start EM 2010 00953.jpg,Siumut,The Premier,kim@nanoq.gl,2014-12-12
+Knud Kristiansen,/media/234532/2010.09.17 Start EM 2010 00916.jpg,Atassut,Member of Naalakkersuisut,knkr@nanoq.gl ,2014-12-12
+Mala  Høy Kuko,/media/2448262/INAT-dukke-lys.jpg,Atassut,Member of Naalakkersuisut,,2014-12-12
+Martha Lund Olsen,/media/759167/Martha_Lund_Olsen.bmp,Siumut,Member of Naalakkersuisut,mlol@nanoq.gl,2014-12-12
+Nivi  Olsen,/media/2448458/INAT-dukke-lys.jpg,Demokraatit,Member of Naalakkersuisut,nivi@nanoq.gl,2014-12-12
+Vittus Qujaukitsoq,/media/762216/Vittus_Qujaukitsoq.jpg,Siumut,Member of Naalakkersuisut,viqu@nanoq.gl,2014-12-12

--- a/data/greenland/incoming/2014-12-12-parl.csv
+++ b/data/greenland/incoming/2014-12-12-parl.csv
@@ -1,0 +1,32 @@
+name,image,party,status,email,term
+Lars-Emil Johansen,/media/753863/Lars-Emil Johansen - 07533.jpg,Siumut,President of Inatsisartut,larsemil@inatsisartut.gl,2014-12-12
+Kim Kielsen,/media/234524/2010.09.17 Start EM 2010 00953.jpg,Siumut,The Premier,kim@nanoq.gl,2014-12-12
+Aaja Chemnitz Larsen,/media/2461849/Aaja Chemnitz Larsen 2014.12 - 15537.jpg,Inuit Ataqatigiit,Member of Inatsisartut,aacl@inatsisartut.gl,2014-12-12
+Agathe Fontain,/media/234537/2010.09.17 Start EM 2010 00896.jpg,Inuit Ataqatigiit,Member of Inatsisartut,agathe@inatsisartut.gl,2014-12-12
+Anders Olsen,/media/293529/untitled-4.jpg,Siumut,Member of Inatsisartut,anols@inatsisartut.gl,2014-12-12
+Ane Hansen,/media/234538/2010.09.17 Start EM 2010 00903.jpg,Inuit Ataqatigiit,Member of Inatsisartut,aneh@inatsisartut.gl,2014-12-12
+Anthon Frederiksen,/media/234539/2010.09.17 Start EM 2010 00946.jpg,Partii Naleraq,Member of Inatsisartut,antuut@inatsisartut.gl,2014-12-12
+Aqqaluaq B. Egede,/media/234438/2010.09.17 Start EM 2010 00886.jpg,Inuit Ataqatigiit,Member of Inatsisartut,aqqe@inatsisartut.gl,2014-12-12
+Hans Enoksen,/media/298458/untitled-6.jpg,Partii Naleraq,Member of Inatsisartut,hans@inatsisartut.gl,2014-12-12
+Iddimanngiiu Bianco,/media/2461401/Iddimanngiiu Bianco 2014.12 - 15527.jpg,Inuit Ataqatigiit,Member of Inatsisartut,idjb@inatsisartut.gl,2014-12-12
+Ineqi Kielsen,/media/2461245/Ineqi Kielsen 2014.12 - 15542.jpg,Siumut,Member of Inatsisartut,ineqi@inatsisartut.gl,2014-12-12
+Jens Immanuelsen,/media/402739/Jens Immanuelsen - 03714.jpg,Siumut,Member of Inatsisartut,jeim@inatsisartut.gl,2014-12-12
+Jens-Erik Kirkegaard,/media/761460/Jens_Erik_Kirkegaard.jpg,Siumut,Substitue,jenserik@inatsisartut.gl,2014-12-12
+Jess Svane,/media/2461089/Jess Svane 2014.12 - 15524.jpg,Siumut,Substitue,jess@inatsisartut.gl,2014-12-12
+Juliane Henningsen,/media/234488/2010.09.17 Start EM 2010 00898.jpg,Inuit Ataqatigiit,Member of Inatsisartut,jhen@inatsisartut.gl,2014-12-12
+Justus Hansen,/media/234516/2010.09.17 Start EM 2010 00888.jpg,Demokraatit,Member of Inatsisartut,justus@inatsisartut.gl,2014-12-12
+Kalistat Lund,/media/719177/Kalistat Lund - 07662.jpg,Inuit Ataqatigiit,Member of Inatsisartut,kalistat@inatsisartut.gl,2014-12-12
+Laura Tàunâjik,/media/2461193/Laura Taunajik 2014.12 - 15533.jpg,Siumut,Member of Inatsisartut,laura@inatsisartut.gl,2014-12-12
+Mùte Bourup Egede,/css/images/INAT-dukke-lys.jpg,Inuit Ataqatigiit,Substitue,mube@inatsisartut.gl,2014-12-12
+Michael Rosing,/media/530703/Michael Rosing - 01220.jpg,Demokraatit,Substitue,michael@inatsisartut.gl,2014-12-12
+Naaja H. Nathanielsen,/media/234421/2010.09.17 Start EM 2010 00941.jpg,Inuit Ataqatigiit,Member of Inatsisartut,nana@inatsisartut.gl,2014-12-12
+Nikolaj Jeremiassen,/media/719823/Nikolaj Jeremiassen - 07666.jpg,Siumut,Member of Inatsisartut,nije@inatsisartut.gl,2014-12-12
+Per Rosing-Petersen,/media/2461609/Per Rosing Petersen 2014.12 - 15506.jpg,Partii Naleraq,Member of Inatsisartut,perrp@inatsisartut.gl,2014-12-12
+Peter Olsen,/media/2462571/Peter Olsen 2014.12 - 15521.jpg,Inuit Ataqatigiit,Member of Inatsisartut,ppol@inatsisartut.gl,2014-12-12
+Randi Vestergaard Evaldsen,/media/2462756/Randi Vestergaard Evaldsen 2014.12 - 15505.jpg,Demokraatit,Member of Inatsisartut,rave@inatsisartut.gl,2014-12-12
+Sara Olsvig,/media/720255/Sara Olsvig - 07669.jpg,Inuit Ataqatigiit,Member of Inatsisartut,saol@inatsisartut.gl,2014-12-12
+Siverth Karl Heilmann,/media/234533/2010.09.17 Start EM 2010 00891.jpg,Atassut,Substitue,skhe@inatsisartut.gl,2014-12-12
+Steen Lynge,/media/762180/Steen_Lynge.jpg,Atassut,Substitue,steen@inatsisartut.gl,2014-12-12
+Suka K. Frederiksen,/media/2461297/Suka K. Frederiksen 2014.12 - 15510.jpg,Siumut,Member of Inatsisartut,suka@inatsisartut.gl,2014-12-12
+Tillie Martinussen,/media/2461141/Tillie Martinussen 2014.12 - 15498.jpg,Demokraatit,Substitue,tillie@inatsisartut.gl,2014-12-12
+Vivian Motzfeldt,/media/2461037/Vivian Motzfeldt 2014.12 - 15515.jpg,Siumut,Substitue,vivian@inatsisartut.gl,2014-12-12


### PR DESCRIPTION
Sinatra has built-in magic `__sinatra__` routes, for things like
images. We need to allow those to pass through our before filter.
