### PR TITLE
Pass `__sinatra__` requests through

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -13,6 +13,9 @@ mapping = {
 }
 
 before '/:country/*' do |country, _|
+  # Allow inbuilt sinatra requests through
+  pass if country == '__sinatra__'
+
   found = mapping.find { |fn, codes| codes.include? country.downcase } or
     halt 404
   @country = found.last.first


### PR DESCRIPTION
Sinatra has built-in magic `__sinatra__` routes, for things like
images. We need to allow those to pass through our before filter.

Before:
![screen shot 2015-04-23 at 08 59 22](https://cloud.githubusercontent.com/assets/57483/7292842/193cfafc-e997-11e4-9ef6-59f810fcfec4.png)

After:
![500 after 2015-04-23 at 09 02 41](https://cloud.githubusercontent.com/assets/57483/7293238/d0904a58-e99a-11e4-8be9-4a16bae40baa.png)


Fixes #52 


I couldn't work out how to test this, as the text runs in test mode, rather than development, which doesn't have the same behaviour, and I couldn't find a way to override that just for a single test. Opening that as #56
