### PR TITLE
Only show legislative memberships on a Person page

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -58,7 +58,7 @@ end
 
 get '/:country/person/:id' do |country, id|
   @person = @popolo.person_from_id(id) or pass
-  @memberships = @popolo.person_memberships(@person)
+  @legislative_memberships = @popolo.person_legislative_memberships(@person)
   erb :person
 end
 

--- a/lib/popolo_helper.rb
+++ b/lib/popolo_helper.rb
@@ -84,6 +84,10 @@ module Popolo
       memberships.find_all { |m| m['person_id'] == p['id'] }
     end
 
+    def person_legislative_memberships(p)
+      legislative_memberships.find_all { |m| m['person_id'] == p['id'] }
+    end
+
     def party_from_id(id)
       p = organizations.detect { |r| r['id'] == id } || organizations.detect { |r| r['id'].end_with? "/#{id}" }
     end
@@ -101,6 +105,7 @@ module Popolo
   module Helper
 
     def generate_url(type, obj)
+      raise "#{type} is Nil" if obj.nil?
       raise "#{type} has no 'id': #{obj}" unless obj.has_key? 'id'
       [ '', @country, type, obj['id'].split('/').last ].join("/")
     end

--- a/t/helpers/wales.rb
+++ b/t/helpers/wales.rb
@@ -15,6 +15,22 @@ describe "Welsh Assembly" do
     it "should get the correct party" do
       party['name'].must_equal 'Plaid Cymru'
     end
+  end
+
+  describe "legislative memberships" do
+
+    let(:person) { subject.person_from_id('169') }
+
+    it "should have both executive and legislative memberships" do
+      mems = subject.person_memberships(person)
+      leg_mems = subject.person_legislative_memberships(person)
+
+      mems.count.must_equal 2
+      leg_mems.count.must_equal 1
+      leg_mems.first['organization']['classification'].must_equal 'legislature'
+      (mems - leg_mems).first['organization']['classification'].must_equal 'executive'
+
+    end
 
   end
 

--- a/t/web/wales.rb
+++ b/t/web/wales.rb
@@ -1,0 +1,37 @@
+ENV['RACK_ENV'] = 'test'
+
+require_relative '../../app'
+require 'minitest/autorun'
+require 'rack/test'
+require 'nokogiri'
+
+include Rack::Test::Methods
+
+def app
+  Sinatra::Application
+end
+
+describe "Wales" do
+
+  subject { Nokogiri::HTML(last_response.body) }
+
+  #-------------------------------------------------------------------
+
+  describe "when viewing a Person with Legislative and Executive memberships" do
+
+    before { get '/wales/person/169' }
+
+    it "should have have their name" do
+      subject.css('h1').text.must_equal 'David Melding'
+    end
+
+    it "should have have their legislative membership" do
+      subject.css('ul li').inner_html.must_include 'Welsh Conservative Party'
+    end
+
+  end
+
+  #-------------------------------------------------------------------
+
+end
+

--- a/views/person.erb
+++ b/views/person.erb
@@ -7,9 +7,9 @@
           <% end %>
         </p>
 
-      <% if @memberships %>
+      <% if @legislative_memberships %>
         <ul>
-          <% @memberships.sort_by { |m| m['start_date'] }.reverse.each do |m| %>
+          <% @legislative_memberships.sort_by { |m| m['start_date'] }.reverse.each do |m| %>
             <li>
                 <a href="<%= party_url(m['on_behalf_of']) %>"><%= m['on_behalf_of']['name'] %></a> representative
                 <% if m['area'] %>


### PR DESCRIPTION
A Person page is breaking when viewing someone who’s in both the Legislature and the Executive

As we’re not really handling Executive positions at all yet, make this display only legislative memberships for now.

Before:
![screen shot 2015-04-23 at 08 59 22](https://cloud.githubusercontent.com/assets/57483/7292842/193cfafc-e997-11e4-9ef6-59f810fcfec4.png)

After:
![david melding 2015-04-23 at 09 58 01](https://cloud.githubusercontent.com/assets/57483/7293736/5b6adcde-e99f-11e4-82e9-809fa2f1cf70.png)


Fixes #51 

<!---
@huboard:{"order":14.0}
-->
