### PR TITLE
Only show each person once on the Term page

### DIFF
--- a/t/web/eduskunta.rb
+++ b/t/web/eduskunta.rb
@@ -97,18 +97,22 @@ describe "Stance viewer" do
 
   describe "when viewing an Term page" do
 
-    before { get '/FI/term/28' }
+    before { get '/FI/term/35' }
 
     it "should have have its name" do
-      subject.css('h1').text.must_equal 'Eduskunta 28 (1979)'
+      subject.css('h1').text.must_equal 'Eduskunta 35 (2007)'
     end
 
-    it "shouldn't show matching term dates" do
-      subject.css('a[href*="103"]').text.wont_include '1979'
+    it "shouldn't show any dates for Mikko Kuoppa" do
+      subject.css('a[href*="444"]').text.wont_include '20'
     end
 
-    it "should show non matching term dates" do
-      subject.css('a[href*="311"]').text.must_include '1979'
+    it "should show early departure date for Matti Vanhanen" do
+      subject.css('a[href*="414"]').text.must_include '2010-09-19'
+    end
+
+    it "should show late start date for Risto Kuisma" do
+      subject.css('a[href*="473"]').text.must_include '2010-07-13'
     end
 
   end

--- a/t/web/eduskunta.rb
+++ b/t/web/eduskunta.rb
@@ -11,7 +11,7 @@ def app
   Sinatra::Application
 end
 
-describe "Stance viewer" do
+describe "Finland" do
 
   subject { Nokogiri::HTML(last_response.body) }
 
@@ -113,6 +113,11 @@ describe "Stance viewer" do
 
     it "should show late start date for Risto Kuisma" do
       subject.css('a[href*="473"]').text.must_include '2010-07-13'
+    end
+
+    it "should only have one entry for Merikukka Forsius" do
+      # Changed Party mid-term
+      subject.css('a[href*="560"]').count.must_equal 1
     end
 
   end

--- a/views/term.erb
+++ b/views/term.erb
@@ -5,13 +5,15 @@
 
       <% if @memberships %>
         <ul class="grid-list">
-          <% @memberships.sort_by { |m| m['person']['name'] }.each do |m| %>
+          <% @memberships.group_by { |m| m['person'] }.sort_by { |p, _| p['name'] }.each do |p, mems| %>
             <li>
-               <a class="avatar-unit" href="<%= person_url(m['person']) %>">
+               <a class="avatar-unit" href="<%= person_url(p) %>">
                    <span class="avatar"><i class="fa fa-user"></i></span>
-                   <h3><%= m['person']['name'] %></h3>
-                   <% if m['start_date'] != @term['start_date'] or m['end_date'] != @term['end_date'] %>
-                     <p><%= m['start_date'] %>–<%= m['end_date'] %></p>
+                   <h3><%= p['name'] %></h3>
+                   <% mems.sort_by { |m| m['start_date'] || @term['start_date'] }.each do |m| %>
+                     <% if m['start_date'] != @term['start_date'] or m['end_date'] != @term['end_date'] %>
+                       <p><%= m['start_date'] %>–<%= m['end_date'] %></p>
+                     <% end %>
                    <% end %>
                </a>
             </li>


### PR DESCRIPTION
As a step towards #60, simply group by Person, and combine their memberships where relevant. 

Where the dates actually combine to span the entire Term, we shouldn't actually show them, but Release Early, Release Often...


Before:
![term before 2015-04-23 at 11 38 16](https://cloud.githubusercontent.com/assets/57483/7295439/e68cc21a-e9ad-11e4-8bb1-5a0c482a427c.png)

After:
![term after 2015-04-23 at 11 38 28](https://cloud.githubusercontent.com/assets/57483/7295396/59b9f466-e9ad-11e4-9e9b-87194630d26d.png)



<!---
@huboard:{"order":67.0,"milestone_order":61,"custom_state":""}
-->
