### PR TITLE
Development Mode test

### DIFF
--- a/t/web/basic.rb
+++ b/t/web/basic.rb
@@ -44,15 +44,5 @@ describe "Viewer" do
     end
   end
 
-  describe "magic sinatra routes" do
-
-    before { get '/__sinatra__/500.png' }
-
-    it "should pass __sinatra__ requests through" do
-      last_response.status.must_equal 200
-    end
-  end
-  
-
 end
 

--- a/t/web/basic.rb
+++ b/t/web/basic.rb
@@ -44,6 +44,15 @@ describe "Viewer" do
     end
   end
 
+  describe "magic sinatra routes" do
+
+    before { get '/__sinatra__/500.png' }
+
+    it "should pass __sinatra__ requests through" do
+      last_response.status.must_equal 200
+    end
+  end
+  
 
 end
 

--- a/t/web/development.rb
+++ b/t/web/development.rb
@@ -1,0 +1,29 @@
+ENV['RACK_ENV'] = 'test'
+
+require_relative '../../app'
+require 'minitest/autorun'
+require 'rack/test'
+require 'nokogiri'
+
+include Rack::Test::Methods
+
+def app
+  Sinatra::Application
+end
+
+describe "Viewer" do
+
+  subject { Nokogiri::HTML(last_response.body) }
+
+  describe "magic sinatra routes" do
+
+    before { get '/__sinatra__/500.png' }
+
+    it "should pass __sinatra__ requests through" do
+      last_response.status.must_equal 200
+    end
+  end
+  
+
+end
+


### PR DESCRIPTION
In #55 I made it so that we don’t clobber the magic `/__sinatra__/` routes, but couldn't work out how to add a test for that.

After talking about it with @chrismytton, it seems that the best way is to just have a separate `development` mode test, as the routes are getting created long before the test runs.

Closes #56