### PR TITLE
65/ Fix Greenland Person pages

### DIFF
--- a/lib/popolo_helper.rb
+++ b/lib/popolo_helper.rb
@@ -29,8 +29,8 @@ module Popolo
         m['person']       ||= promise { person_from_id(m['person_id'])      }
         if m.has_key?('legislative_period_id')
           m['legislative_period'] ||= promise { term_from_id(m['legislative_period_id']) }
-          m['start_date'] ||= promise { m['legislative_period']['start_date'] }
-          m['end_date'] ||= promise { m['legislative_period']['end_date'] }
+          m['start_date'] ||= promise { m['legislative_period']['start_date'] || '' }
+          m['end_date'] ||= promise { m['legislative_period']['end_date'] || '' }
         end
         m
       }

--- a/t/web/greenland.rb
+++ b/t/web/greenland.rb
@@ -33,5 +33,17 @@ describe "Greenland" do
 
   #-------------------------------------------------------------------
 
+  describe "when viewing person " do
+
+    before { get '/greenland/person/56b7da86-b9c7-4fcd-bd04-f980cde7d4c5' }
+
+    it "should have have their name" do
+      subject.css('h1').text.must_equal 'Agathe Fontain'
+    end
+
+  end
+
+  #-------------------------------------------------------------------
+
 end
 


### PR DESCRIPTION
If there’s no start/end date on a Membership, or the Legislative
Period, sorting fails (as it can’t compare Promises)

Before: 
![gl person 2015-04-24 at 09 39 31](https://cloud.githubusercontent.com/assets/57483/7315493/dd7f7a7e-ea65-11e4-9ad0-e11b6e8cbd47.png)

After:
![gl person 2015-04-24 at 09 54 53](https://cloud.githubusercontent.com/assets/57483/7315796/ce11187e-ea68-11e4-9438-a895a05d0eb8.png)


Fixes #65