### PR TITLE
58/ Show Terms on Person page

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -23,6 +23,7 @@ before '/:country/*' do |country, _|
   @popolo = Popolo::Data.new(found.first)
 end
 
+set :erb, :trim => '-' 
 
 get '/' do
   @countries = mapping.map { |k, v| v.first }

--- a/t/web/greenland.rb
+++ b/t/web/greenland.rb
@@ -38,7 +38,11 @@ describe "Greenland" do
     before { get '/greenland/person/56b7da86-b9c7-4fcd-bd04-f980cde7d4c5' }
 
     it "should have have their name" do
-      subject.css('h1').text.must_equal 'Agathe Fontain'
+      subject.css('#person h1').text.must_equal 'Agathe Fontain'
+    end
+
+    it "should have term links" do
+      subject.css('#person ul li').inner_html.must_include '/term/'
     end
 
   end

--- a/views/person.erb
+++ b/views/person.erb
@@ -9,13 +9,18 @@
 
       <% if @legislative_memberships %>
         <ul>
-          <% @legislative_memberships.sort_by { |m| m['start_date'] }.reverse.each do |m| %>
+          <%- @legislative_memberships.sort_by { |m| m['start_date'] }.reverse.each do |m| %>
             <li>
-                <a href="<%= party_url(m['on_behalf_of']) %>"><%= m['on_behalf_of']['name'] %></a> representative
-                <% if m['area'] %>
-                  for <a href="<%= area_name_url(m['area']['name']) %>"><%= m['area']['name'] %></a>
-                <% end %>
-                (<%= m['start_date'] %>–<%= m['end_date'] %>)
+            <%- if m['legislative_period'] -%>
+              <i class="fa fa-university"></i> <a href="<%= term_url(m['legislative_period']) %>"><%= m['legislative_period']['name'] %>:
+            <% end %>
+              <a href="<%= party_url(m['on_behalf_of']) %>"><%= m['on_behalf_of']['name'] %></a> representative
+            <%- if m['area'] -%>
+              for <a href="<%= area_name_url(m['area']['name']) %>"><%= m['area']['name'] %></a>
+            <% end %>
+            <% unless m['start_date'].to_s.empty? and m['end_date'].to_s.empty? %>
+              (<%= m['start_date'] %>–<%= m['end_date'] %>)
+            <% end %>
             </li>
           <% end %>
         </ul>


### PR DESCRIPTION
Add the relevant Term information to the list of legislative memberships on the Person page.


Before: 
![gl person 2015-04-24 at 09 54 53](https://cloud.githubusercontent.com/assets/57483/7315796/ce11187e-ea68-11e4-9438-a895a05d0eb8.png)

After:
![person terms 2015-04-24 at 10 32 01](https://cloud.githubusercontent.com/assets/57483/7316679/f2cf03e4-ea70-11e4-9eb8-2e2f6c373109.png)

Closes #58 
