### PR TITLE
69: /person/name

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -61,7 +61,12 @@ get '/:country/term/:id' do |country, id|
 end
 
 get '/:country/person/:id' do |country, id|
-  @person = @popolo.person_from_id(id) or pass
+  @person = @popolo.person_from_id(id) 
+  unless @person
+    people = @popolo.people_with_name(id) or pass
+    #TODO handle having more than one person with the same name
+    @person = people.first
+  end
   @legislative_memberships = @popolo.person_legislative_memberships(@person)
   erb :person
 end

--- a/lib/popolo_helper.rb
+++ b/lib/popolo_helper.rb
@@ -80,6 +80,10 @@ module Popolo
       persons.detect { |r| r['id'] == id } || persons.detect { |r| r['id'].end_with? "/#{id}" }
     end
 
+    def people_with_name(name)
+      persons.find_all { |p| p['name'] == name } 
+    end
+
     def person_memberships(p)
       memberships.find_all { |m| m['person_id'] == p['id'] }
     end

--- a/t/helpers/eduskunta.rb
+++ b/t/helpers/eduskunta.rb
@@ -123,4 +123,18 @@ describe "Eduskunta" do
 
   end
 
+  describe "person by name" do
+
+    let(:people) { subject.people_with_name('Stubb Alexander') }
+
+    it "should get one person" do
+      people.count.must_equal 1
+    end
+
+    it "should get the correct person" do
+      people.first['name'].must_equal 'Stubb Alexander'
+    end
+
+  end
+
 end

--- a/t/web/greenland.rb
+++ b/t/web/greenland.rb
@@ -33,9 +33,11 @@ describe "Greenland" do
 
   #-------------------------------------------------------------------
 
-  describe "when viewing person " do
+  describe "when viewing person by name" do
 
-    before { get '/greenland/person/56b7da86-b9c7-4fcd-bd04-f980cde7d4c5' }
+    # Using a + here no longer works in Sinatra. See discussion at 
+    # https://github.com/chriso/klein.php/issues/117
+    before { get '/greenland/person/Agathe%20Fontain' }
 
     it "should have have their name" do
       subject.css('h1').text.must_equal 'Agathe Fontain'


### PR DESCRIPTION
Allow /person/name as well as /person/id

This will only work for an exact match on name, and doesn’t handle
multiple people having the same name.

<!---
@huboard:{"order":66.5,"milestone_order":70,"custom_state":""}
-->
