### PR TITLE
74/ Empty terms

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -39,7 +39,7 @@ get '/:country/' do
 end
 
 get '/:country/terms.html' do
-  @terms = @popolo.terms
+  @terms = @popolo.terms_with_members
   erb :terms
 end
 

--- a/lib/popolo_helper.rb
+++ b/lib/popolo_helper.rb
@@ -49,6 +49,10 @@ module Popolo
       legislature['legislative_periods'] || legislature['terms'] 
     end
 
+    def terms_with_members
+      terms.reject { |t| term_memberships(t).count.zero? }
+    end
+
     # This will need to become a lot fancier, but it'll do for now
     def current_term
       terms.find { |t| not t.has_key? 'end_date' }

--- a/t/helpers/eduskunta.rb
+++ b/t/helpers/eduskunta.rb
@@ -77,6 +77,19 @@ describe "Eduskunta" do
 
   end
 
+  describe "terms with members" do
+    let(:terms) { subject.terms_with_members }
+
+    it "should include 25" do
+      terms.map { |t| t['name'] }.must_include 'Eduskunta 25 (1970)'
+    end
+
+    it "shouldn't include 24" do
+      terms.map { |t| t['name'] }.wont_include 'Eduskunta 24 (1966)'
+    end
+
+  end
+
   describe "current term" do
     let(:term) { subject.current_term }
 

--- a/t/web/eduskunta-old.rb
+++ b/t/web/eduskunta-old.rb
@@ -32,12 +32,12 @@ describe "Stance viewer" do
 
     before { get '/suomi/terms.html' }
 
-    it "should have at least 35 terms" do
-      subject.css('#terms ul li').count.must_be :>, 35
+    it "should have at least 12 terms" do
+      subject.css('#terms ul li').count.must_be :>, 12
     end
 
-    it "should have the first term last" do
-      subject.css('#terms ul li:last').text.must_include 'Eduskunta 1 (1907)'
+    it "should go back to 1970" do
+      subject.css('#terms ul li:last').text.must_include 'Eduskunta 25 (1970)'
     end
 
   end

--- a/t/web/eduskunta-old.rb
+++ b/t/web/eduskunta-old.rb
@@ -33,7 +33,7 @@ describe "Stance viewer" do
     before { get '/suomi/terms.html' }
 
     it "should have at least 12 terms" do
-      subject.css('#terms ul li').count.must_be :>, 12
+      subject.css('#terms ul li').count.must_be :>=, 12
     end
 
     it "should go back to 1970" do

--- a/t/web/eduskunta.rb
+++ b/t/web/eduskunta.rb
@@ -33,7 +33,7 @@ describe "Finland" do
     before { get '/finland/terms.html' }
 
     it "should have at least 12 terms" do
-      subject.css('#terms ul li').count.must_be :>, 12
+      subject.css('#terms ul li').count.must_be :>=, 12
     end
 
     it "should go back to 1970" do

--- a/t/web/eduskunta.rb
+++ b/t/web/eduskunta.rb
@@ -32,12 +32,12 @@ describe "Finland" do
 
     before { get '/finland/terms.html' }
 
-    it "should have at least 35 terms" do
-      subject.css('#terms ul li').count.must_be :>, 35
+    it "should have at least 12 terms" do
+      subject.css('#terms ul li').count.must_be :>, 12
     end
 
-    it "should have the first term last" do
-      subject.css('#terms ul li:last').text.must_include 'Eduskunta 1 (1907)'
+    it "should go back to 1970" do
+      subject.css('#terms ul li:last').text.must_include 'Eduskunta 25 (1970)'
     end
 
   end


### PR DESCRIPTION
on the Terms page, only provide links to Terms that actually have
members.

Before:
![empty terms 2015-04-24 at 15 45 51](https://cloud.githubusercontent.com/assets/57483/7321252/0f1f9f68-ea99-11e4-968f-0673505b3064.png)


After:
![terms 2015-04-24 at 16 30 17](https://cloud.githubusercontent.com/assets/57483/7322349/6c13119a-ea9f-11e4-96cc-5f5030b8a1c4.png)



Closes #74