### PR TITLE
Test for no such person

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -64,9 +64,9 @@ end
 get '/:country/person/:id' do |country, id|
   @person = @popolo.person_from_id(id) 
   unless @person
-    people = @popolo.people_with_name(id) or pass
+    people = @popolo.people_with_name(id)
     #TODO handle having more than one person with the same name
-    @person = people.first
+    @person = people.first or pass
   end
   @legislative_memberships = @popolo.person_legislative_memberships(@person)
   erb :person

--- a/t/web/greenland.rb
+++ b/t/web/greenland.rb
@@ -33,6 +33,18 @@ describe "Greenland" do
 
   #-------------------------------------------------------------------
 
+  describe "when viewing missing person" do
+
+    before { get '/greenland/person/nope' }
+
+    it "should 404" do
+      last_response.status.must_equal 404
+    end
+
+  end
+
+  #-------------------------------------------------------------------
+
   describe "when viewing person by name" do
 
     # Using a + here no longer works in Sinatra. See discussion at 


### PR DESCRIPTION
When introducing the ‘find by name’ I got ruby’s truthiness test wrong (an empty list is `true`, not `false`). Move the check to the right place, and add a regression test.