### PR TITLE
Tie Terms and Parties better

### DIFF
--- a/t/web/eduskunta.rb
+++ b/t/web/eduskunta.rb
@@ -136,12 +136,13 @@ describe "Finland" do
       subject.css('h1').text.must_equal 'National Coalition Party'
     end
 
-    it "should have many MPs" do
-      subject.css('#party ul li').count.must_be :>, 20
+    it "should have many Terms" do
+      subject.css('#party ul li').count.must_be :>=, 12
     end
 
-    it "should include Stubb" do
-      subject.css('#party ul li').text.must_include 'Stubb Alexander'
+    it "going back to Eduskunta 25" do
+      subject.css('#party ul li:last').text.must_include 'Eduskunta 25'
+      subject.css('#party ul li:last').text.must_include '1 seat'
     end
 
   end

--- a/views/party.erb
+++ b/views/party.erb
@@ -3,16 +3,19 @@
         <h1><%= @party['name'] %></h1>
 
       <% if @memberships %>
-        <h3>Members</h3>
+        <h3>Seats</h3>
         <ul class="grid-list">
-          <% @memberships.each do |m| %>
+
+          <% @memberships.group_by { |m| m['legislative_period'] }.sort_by { |t, _| t['start_date'] }.reverse.each do |t, ms| %>
             <li>
-                <a class="avatar-unit" href="<%= person_url(m['person']) %>">
-                    <span class="avatar"><i class="fa fa-user"></i></span>
-                    <h3><%= m['person']['name'] %></h3>
+                <a class="avatar-unit" href="<%= term_url(t) %>">
+                    <span class="avatar"><i class="fa fa-university"></i></span>
+                    <h3><%= t['name'] %></h3>
+                    <p><%= ms.count %> seat<% if ms.count > 1 %>s<% end %></p>
                 </a>
             </li>
           <% end %>
+
         </ul>
       <% else %>
         <h3>No members</h3>

--- a/views/term.erb
+++ b/views/term.erb
@@ -8,7 +8,7 @@
           <a class="avatar-unit" href="<%= party_url(party) %>">
             <span class="avatar"><i class="fa fa-users"></i></span>
             <h2><%= party['name'] %></h2>
-            <p>(<%= mems.count %> member<% if mems.count > 1 %>s<% end %>)</p>
+            <p>(<%= mems.count %> seat<% if mems.count > 1 %>s<% end %>)</p>
           </a>
 
           <div class="container">

--- a/views/term.erb
+++ b/views/term.erb
@@ -4,23 +4,32 @@
     <p><%= @term['start_date'] %> – <%= @term['end_date'] %></p>
     <% if @memberships %>
       <% @memberships.group_by { |m| m['on_behalf_of'] }.sort_by { |party, ms| ms.count }.reverse.each do |party, mems| %>
-        <h2 class="text-center"><%= party['name'] %></h2>
-        <p class="text-center">(<%= mems.count %> member<% if mems.count > 1 %>s<% end %>)</p>
-        <ul class="grid-list">
-        <% mems.group_by { |m| m['person'] }.sort_by { |p, _| p['name'] }.each do |p, mems| %>
-          <li>
-            <a class="avatar-unit" href="<%= person_url(p) %>">
-              <span class="avatar"><i class="fa fa-user"></i></span>
-              <h3><%= p['name'] %></h3>
-              <% mems.sort_by { |m| m['start_date'] || @term['start_date'] }.each do |m| %>
-                <% if m['start_date'].to_s != @term['start_date'].to_s or m['end_date'].to_s != @term['end_date'].to_s %>
-                <p><%= m['start_date'] %>–<%= m['end_date'] %></p>
-                <% end %>
-              <% end %>
-            </a>
-          </li>
-        <% end %>
-        </ul>
+        <div class="container">
+          <a class="avatar-unit" href="<%= party_url(party) %>">
+            <span class="avatar"><i class="fa fa-users"></i></span>
+            <h2><%= party['name'] %></h2>
+            <p>(<%= mems.count %> member<% if mems.count > 1 %>s<% end %>)</p>
+          </a>
+
+          <div class="container">
+            <ul class="grid-list">
+            <% mems.group_by { |m| m['person'] }.sort_by { |p, _| p['name'] }.each do |p, mems| %>
+              <li>
+                <a class="avatar-unit" href="<%= person_url(p) %>">
+                  <span class="avatar"><i class="fa fa-user"></i></span>
+                  <h3><%= p['name'] %></h3>
+                  <% mems.sort_by { |m| m['start_date'] || @term['start_date'] }.each do |m| %>
+                    <% if m['start_date'].to_s != @term['start_date'].to_s or m['end_date'].to_s != @term['end_date'].to_s %>
+                    <p><%= m['start_date'] %>–<%= m['end_date'] %></p>
+                    <% end %>
+                  <% end %>
+                </a>
+              </li>
+            <% end %>
+            </ul>
+          </div>
+
+      </div>
       <% end %>
     <% end %>
     </div>


### PR DESCRIPTION
- On the Party page show how many Seats they’ve had in each Term

before:
![party before 2015-04-24 at 22 09 27](https://cloud.githubusercontent.com/assets/57483/7328649/f68a840a-eace-11e4-9c30-f150832d1853.png)

after:
![party after 2015-04-24 at 22 07 13](https://cloud.githubusercontent.com/assets/57483/7328650/f8e3b154-eace-11e4-810e-bc366bb7fbb3.png)


- On the Term page, link to the Party page

before:
![term before 2015-04-24 at 22 09 15](https://cloud.githubusercontent.com/assets/57483/7328645/f0f7a9aa-eace-11e4-8347-1e682e7e5f9d.png)

after:
![term after 2015-04-24 at 22 07 01](https://cloud.githubusercontent.com/assets/57483/7328647/f3935114-eace-11e4-8993-1433f9609705.png)


Closes #22 