### PR TITLE
Area Page

### DIFF
--- a/views/area.erb
+++ b/views/area.erb
@@ -1,19 +1,31 @@
 <div class="page-section" id="area">
-    <div class="container">
-        <h1><%= @area['name'] %></h1>
+  <div class="container">
+    <h1><%= @area['name'] %></h1>
 
-      <% if @memberships %>
-        <ul class="grid-list">
-          <% @memberships.sort_by { |m| [m['end_date'] || '9999-99-99', m['start_date'] || '1111-11-11'] }.reverse.each do |m| %>
-            <li>
+    <% if @memberships %>
+      <% @memberships.group_by { |m| m['legislative_period'] }.sort_by { |t, _| t['start_date'] }.reverse.each do |t, ms| %>
+        <a class="avatar-unit" href="<%= term_url(t) %>">
+          <span class="avatar"><i class="fa fa-university"></i></span>
+          <h2><%= t['name'] %></h2>
+        </a>
+
+        <div class="container">
+          <ul class="grid-list">
+            <% ms.each do |m| %>
+              <li>
                 <a class="avatar-unit" href="<%= person_url(m['person']) %>">
-                    <span class="avatar"><i class="fa fa-user"></i></span>
-                    <h3><%= m['person']['name'] %></h3>
+                  <span class="avatar"><i class="fa fa-user"></i></span>
+                  <h3><%= m['person']['name'] %></h3>
+                  <% if m['start_date'].to_s != t['start_date'].to_s or m['end_date'].to_s != t['end_date'].to_s %>
                     <p><%= m['start_date'] %>–<%= m['end_date'] %></p>
+                  <% end %>
                 </a>
-            </li>
-          <% end %>
-        </ul>
+              </li>
+            <% end %>
+          </ul>
+        </div>
+
       <% end %>
-    </div>
+    <% end %>
+  </div>
 </div>

--- a/views/area.erb
+++ b/views/area.erb
@@ -10,19 +10,31 @@
         </a>
 
         <div class="container">
-          <ul class="grid-list">
-            <% ms.each do |m| %>
-              <li>
-                <a class="avatar-unit" href="<%= person_url(m['person']) %>">
-                  <span class="avatar"><i class="fa fa-user"></i></span>
-                  <h3><%= m['person']['name'] %></h3>
-                  <% if m['start_date'].to_s != t['start_date'].to_s or m['end_date'].to_s != t['end_date'].to_s %>
-                    <p><%= m['start_date'] %>–<%= m['end_date'] %></p>
-                  <% end %>
-                </a>
-              </li>
-            <% end %>
-          </ul>
+          <% ms.group_by { |m| m['on_behalf_of'] }.each do |p, ms| %>
+
+            <a class="avatar-unit" href="<%= party_url(p) %>">
+              <span class="avatar"><i class="fa fa-users"></i></span>
+              <h2><%= p['name'] %></h2>
+            </a>
+
+            <div class="container">
+              <ul class="grid-list">
+
+                <% ms.each do |m| %>
+                  <li>
+                    <a class="avatar-unit" href="<%= person_url(m['person']) %>">
+                      <span class="avatar"><i class="fa fa-user"></i></span>
+                      <h3><%= m['person']['name'] %></h3>
+                      <% if m['start_date'].to_s != t['start_date'].to_s or m['end_date'].to_s != t['end_date'].to_s %>
+                        <p><%= m['start_date'] %>–<%= m['end_date'] %></p>
+                      <% end %>
+                    </a>
+                  </li>
+                <% end %>
+
+              </ul>
+            </div>
+          <% end %>
         </div>
 
       <% end %>


### PR DESCRIPTION
Group by Term + Party, instead of just a giant list of undifferentiated memberships. It still doesn't really work very well — if it's a single-member constituency it's very cluttered, and if it's multi-member with a lot of members and a lot of terms it goes on forever. But this should at least give us something to design against.

Before (single member):

![area wales before 2015-04-24 at 22 40 40](https://cloud.githubusercontent.com/assets/57483/7329056/2cc1c138-ead3-11e4-91d0-6b67768726bf.png)

After (single member):
![area wales 2015-04-24 at 22 38 50](https://cloud.githubusercontent.com/assets/57483/7329057/3618d42e-ead3-11e4-9ae2-9c2b7b0f1d71.png)


Before (multi-member):
![area finland before 2015-04-24 at 22 40 53](https://cloud.githubusercontent.com/assets/57483/7329059/38af654a-ead3-11e4-844e-e306f95874c9.png)

After (multi-member):
![area finland 2015-04-24 at 22 39 10](https://cloud.githubusercontent.com/assets/57483/7329060/3c4ab664-ead3-11e4-92e4-d53db0843adc.png)


Closes: #79 