### PR TITLE
Add a basic term_table page

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -61,6 +61,18 @@ get '/:country/term/:id' do |country, id|
   erb :term
 end
 
+get '/:country/term_table/?' do |country|
+  @term = @popolo.current_term
+  @memberships = @popolo.term_memberships(@term)
+  erb :term_table
+end
+
+get '/:country/term_table/:id' do |country, id|
+  @term = @popolo.term_from_id(id) or pass
+  @memberships = @popolo.term_memberships(@term)
+  erb :term_table
+end
+
 get '/:country/person/:id' do |country, id|
   @person = @popolo.person_from_id(id) 
   unless @person

--- a/t/web/term_table.rb
+++ b/t/web/term_table.rb
@@ -1,0 +1,76 @@
+ENV['RACK_ENV'] = 'test'
+
+require_relative '../../app'
+require 'minitest/autorun'
+require 'rack/test'
+require 'nokogiri'
+
+include Rack::Test::Methods
+
+def app
+  Sinatra::Application
+end
+
+describe "Basic loads" do
+
+  it "should be able to load every country" do
+    
+    # Get the list of countries on the homepage
+    frontpage = get('/')
+    countries = Nokogiri::HTML(last_response.body).css('#home ul.grid-list li a').map { |n|
+      n.attr('href').split('/')[1]
+    }
+
+    # Then ensure the current term table for each loads OK
+    countries.each do |country|
+      url = "/#{country}/term_table"
+      get(url)
+      last_response.status.must_equal 200
+      noko = Nokogiri::HTML(last_response.body)
+      noko.css('table th').text.must_include 'Name'
+    end
+
+  end
+
+end
+
+# Country-specific tests for edge cases
+
+
+describe "Finland" do
+
+  before { get '/finland/term_table/35' }
+
+  subject { Nokogiri::HTML(last_response.body) }
+
+  it "should have have its name" do
+    subject.css('#term h1').text.must_include 'Eduskunta 35 (2007)'
+  end
+
+  it "should list the parties" do
+    subject.css('#term table').text.must_include 'Finnish Centre Party'
+  end
+
+  it "should list the areas" do
+    subject.css('#term table').text.must_include 'Oulun'
+  end
+
+  it "shouldn't show any dates for Mikko Kuoppa" do
+    subject.css('tr#mem-444').text.wont_include '20'
+  end
+
+  it "should show early departure date for Matti Vanhanen" do
+    subject.css('tr#mem-414 td:last').text.must_include '2010-09-19'
+  end
+
+  it "should show late start date for Risto Kuisma" do
+    subject.css('tr#mem-473 td:last').text.must_include '2010-07-13'
+  end
+
+  it "should have two rows for Merikukka Forsius" do
+    # Changed Party mid-term, so one entry per party
+    subject.at_css('tr#mem-560 td:first').attr('rowspan').to_i.must_equal 2
+  end
+
+end
+

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -1,0 +1,37 @@
+<div class="page-section" id="term">
+  <div class="container">
+    <h1><span class="avatar"><i class="fa fa-university"></i></span> <%= @term['name'] %></h1>
+    <% unless @term['start_date'].to_s.empty? and @term['end_date'].to_s.empty? %>
+      <p><%= @term['start_date'] %> – <%= @term['end_date'] %></p>
+    <% end %>
+
+    <% if @memberships.count.zero? %>
+      
+    <% else %>
+      <table>
+        <tr>
+          <th>Name</th>
+          <th>Group</th>
+          <th>Area</th>
+          <th>Dates</th>
+        </tr>
+
+      <% @memberships.group_by { |m| m['person'] }.sort_by { |p, _| p['name'] }.each do |p, mems| %>
+        <tr id="mem-<%= p['id'].split('/').last %>">
+          <td rowspan="<%= mems.count %>"><%= p['name'] %></td>
+          <% mems.each do |m| %>
+            <td><%= m['on_behalf_of']['name'] %></td>
+            <td><%= m['area'] && m['area']['name'] %></td>
+            <td> 
+              <% if m['start_date'].to_s != @term['start_date'].to_s or m['end_date'].to_s != @term['end_date'].to_s %>
+                <p><%= m['start_date'] %>–<%= m['end_date'] %></p>
+              <% end %>
+            </td>
+          </tr>
+          <% end %>
+      <% end %>
+      </table>
+
+    <% end %>
+    </div>
+</div>


### PR DESCRIPTION
For each country, have a simple table that shows the legislature during that term. This can be accessed by id, or simply visiting `/country/term_table` will default to the current term.

![term table 2015-04-27 at 14 54 51](https://cloud.githubusercontent.com/assets/57483/7348924/679993dc-eced-11e4-83ac-3fe63a38c6a2.png)

Party changes, etc, are simply shown as grouped rows:
![change party 2015-04-27 at 14 55 19](https://cloud.githubusercontent.com/assets/57483/7348938/79db2fc4-eced-11e4-8712-0c8c3bea8ea8.png)
