### PR TITLE
Term Navigation

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -63,12 +63,16 @@ end
 
 get '/:country/term_table/?' do |country|
   @term = @popolo.current_term
+  @terms = @popolo.term_list
+  (@prev_term, _, @next_term) = [nil, @terms, nil].flatten.each_cons(3).find { |p, e, n| e['id'] == @term['id'] }
   @memberships = @popolo.term_memberships(@term)
   erb :term_table
 end
 
 get '/:country/term_table/:id' do |country, id|
   @term = @popolo.term_from_id(id) or pass
+  @terms = @popolo.term_list
+  (@prev_term, _, @next_term) = [nil, @terms, nil].flatten.each_cons(3).find { |p, e, n| e['id'] == @term['id'] }
   @memberships = @popolo.term_memberships(@term)
   erb :term_table
 end

--- a/app.rb
+++ b/app.rb
@@ -61,16 +61,9 @@ get '/:country/term/:id' do |country, id|
   erb :term
 end
 
-get '/:country/term_table/?' do |country|
-  @term = @popolo.current_term
-  @terms = @popolo.term_list
-  (@prev_term, _, @next_term) = [nil, @terms, nil].flatten.each_cons(3).find { |p, e, n| e['id'] == @term['id'] }
-  @memberships = @popolo.term_memberships(@term)
-  erb :term_table
-end
-
-get '/:country/term_table/:id' do |country, id|
-  @term = @popolo.term_from_id(id) or pass
+get '/:country/term_table/?:id?' do |country, id|
+  @term = id ? @popolo.term_from_id(id) :  @popolo.current_term
+  pass unless @term
   @terms = @popolo.term_list
   (@prev_term, _, @next_term) = [nil, @terms, nil].flatten.each_cons(3).find { |p, e, n| e['id'] == @term['id'] }
   @memberships = @popolo.term_memberships(@term)

--- a/lib/popolo_helper.rb
+++ b/lib/popolo_helper.rb
@@ -49,19 +49,21 @@ module Popolo
       legislature['legislative_periods'] || legislature['terms'] 
     end
 
+    def term_list
+      terms.sort_by { |t| [ (t['start_date'] || '1001-01-01'), (t['end_date'] || '2999-12-31') ] }
+    end
+
     def terms_with_members
       terms.reject { |t| term_memberships(t).count.zero? }
     end
 
-    # This will need to become a lot fancier, but it'll do for now
     def current_term
-      terms.find { |t| not t.has_key? 'end_date' }
+      term_list.last 
     end
 
     def legislative_memberships
       memberships.find_all { |m| m['organization_id'] == 'legislature' }
     end
-
 
     def term_from_id(id)
       terms.detect { |t| t['id'] == id } || terms.detect { |t| t['id'].end_with? "/#{id}" }
@@ -119,6 +121,10 @@ module Popolo
 
     def term_url(t)
       generate_url('term', t)
+    end
+
+    def term_table_url(t)
+      generate_url('term_table', t)
     end
 
     def area_name_url(t)

--- a/t/web/term_table.rb
+++ b/t/web/term_table.rb
@@ -72,5 +72,17 @@ describe "Finland" do
     subject.at_css('tr#mem-560 td:first').attr('rowspan').to_i.must_equal 2
   end
 
+  it "should link to 34" do
+    subject.css('a[href*="/term_table/34"]').count.must_be :>=, 1
+  end
+
+  it "should link to 36" do
+    subject.css('a[href*="/term_table/36"]').count.must_be :>=, 1
+  end
+
+  it "shouldn't link to 33" do
+    subject.css('a[href*="/term_table/33"]').count.must_equal 0
+  end
+
 end
 

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -1,9 +1,23 @@
 <div class="page-section" id="term">
   <div class="container">
-    <h1><span class="avatar"><i class="fa fa-university"></i></span> <%= @term['name'] %></h1>
+    <h1 class="text-center"><span class="avatar"><i class="fa fa-university"></i></span> <%= @term['name'] %></h1>
     <% unless @term['start_date'].to_s.empty? and @term['end_date'].to_s.empty? %>
-      <p><%= @term['start_date'] %> – <%= @term['end_date'] %></p>
+      <p class="text-center"><%= @term['start_date'] %> – <%= @term['end_date'] %></p>
     <% end %>
+
+    <p>
+    <% if @prev_term %>
+      <span><a href="<%= term_table_url(@prev_term) %>">
+        <i class="fa fa-arrow-left"></i> <%= @prev_term['name'] %>
+      </a></span>
+    <% end %>
+
+    <% if @next_term %>
+      <span style="float:right"><a href="<%= term_table_url(@next_term) %>">
+          <%= @next_term['name'] %> <i class="fa fa-arrow-right"></i>
+      </a></span>
+    <% end %>
+    </p>
 
     <% if @memberships.count.zero? %>
       


### PR DESCRIPTION
Allow navigation backwards and forwards on Term Table pages. (Closes #101)

Also make the `current_term` call a little more robust (closes #104)

![next prev 2015-04-27 at 19 14 17](https://cloud.githubusercontent.com/assets/57483/7354214/a8d8b354-ed11-11e4-808a-61b6a63a5366.png)


<!---
@huboard:{"order":51.5,"milestone_order":107,"custom_state":""}
-->
