### PR TITLE
Add basic Party Groupings box

### DIFF
--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -22,6 +22,20 @@
     <% if @memberships.count.zero? %>
       
     <% else %>
+      <h2>Party Groupings</h2>
+
+      <ul class="grid-list">
+        <% @memberships.group_by { |m| m['on_behalf_of'] }.sort_by { |p, ms| ms.count }.reverse.each do |party, mems| %>
+          <li><div class="avatar-unit">
+            <span class="avatar"><i class="fa fa-users"></i></span>
+            <h3><%= party['name'] %></h3>
+            <p><%= mems.count %> seat<% if mems.count > 1 %>s<% end %></p>
+          </div></li>
+        <% end %>
+      </ul>
+
+      <h2>Members</h3>
+
       <table>
         <tr>
           <th>Name</th>


### PR DESCRIPTION
Add a count of how many seats each party group had during this Term.
It’s not ideal, as it simply counts the number of Memberships over the
Term, but it’s a good first step, and lets us style the page better
whilst we work out what the correct calculations should be.

Closes #98 (#111 will be the more advanced version)