### PR TITLE
Split Term Table for bicameral legislatures

### DIFF
--- a/data/australia.json
+++ b/data/australia.json
@@ -5529,13 +5529,13 @@
     },
     {
       "id": "chamber/representatives",
-      "name": "representatives",
+      "name": "House of Representatives",
       "classification": "chamber",
       "parent_id": "legislature"
     },
     {
       "id": "chamber/senate",
-      "name": "senate",
+      "name": "Senate",
       "classification": "chamber",
       "parent_id": "legislature"
     },

--- a/data/australia/Rakefile.rb
+++ b/data/australia/Rakefile.rb
@@ -37,8 +37,13 @@ task :load_json => 'fromcsv.json'
 
 
 task :connect_chambers => :ensure_legislature_exists do
+  better_name = { 
+    'senate' => 'Senate',
+    'representatives' => 'House of Representatives',
+  }
   @json[:organizations].find_all { |h| h[:classification] == 'chamber' }.each do |c|
-    c['parent_id'] ||= 'legislature'
+    c[:name] = better_name[c[:name]] || c[:name]
+    c[:parent_id] ||= 'legislature'
   end
 end
 

--- a/data/australia/processed.json
+++ b/data/australia/processed.json
@@ -5529,13 +5529,13 @@
     },
     {
       "id": "chamber/representatives",
-      "name": "representatives",
+      "name": "House of Representatives",
       "classification": "chamber",
       "parent_id": "legislature"
     },
     {
       "id": "chamber/senate",
-      "name": "senate",
+      "name": "Senate",
       "classification": "chamber",
       "parent_id": "legislature"
     },

--- a/t/web/term_table.rb
+++ b/t/web/term_table.rb
@@ -86,6 +86,11 @@ describe "Per Country Tests" do
       subject.css('a[href*="/term_table/33"]').count.must_equal 0
     end
 
+    it "shouldn't have a heading for the house name" do
+      subject.css('h3').text.downcase.wont_include 'eduskunta'
+    end
+
+
   end
 
   describe "Australia" do
@@ -93,11 +98,15 @@ describe "Per Country Tests" do
     before { get '/australia/term_table/' }
 
     it "should include a Representative" do
-      subject.at_css('tr#mem-EZ5 td:first').text.must_include 'Tony Abbott'
+      subject.at_css('#house-representatives tr#mem-EZ5 td:first').text.must_include 'Tony Abbott'
     end
 
     it "should include a Senator" do
-      subject.at_css('tr#mem-GB6 td:first').text.must_include 'Jacinta Collins'
+      subject.at_css('#house-senate tr#mem-GB6 td:first').text.must_include 'Jacinta Collins'
+    end
+
+    it "should have a heading for the house name" do
+      subject.css('h3').text.downcase.must_include 'senate'
     end
 
   end

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -36,30 +36,33 @@
 
       <h2>Members</h3>
 
-      <table>
-        <tr>
-          <th>Name</th>
-          <th>Group</th>
-          <th>Area</th>
-          <th>Dates</th>
-        </tr>
-
-      <% @memberships.group_by { |m| m['person'] }.sort_by { |p, _| p['name'] }.each do |p, mems| %>
-        <tr id="mem-<%= p['id'].split('/').last %>">
-          <td rowspan="<%= mems.count %>"><%= p['name'] %></td>
-          <% mems.each do |m| %>
-            <td><%= m['on_behalf_of']['name'] %></td>
-            <td><%= m['area'] && m['area']['name'] %></td>
-            <td> 
-              <% if m['start_date'].to_s != @term['start_date'].to_s or m['end_date'].to_s != @term['end_date'].to_s %>
-                <p><%= m['start_date'] %>–<%= m['end_date'] %></p>
-              <% end %>
-            </td>
+      <% @memberships.group_by { |m| m['organization'] }.each do |leg, leg_mems| %>
+        <h3><%= leg['name'] %></h3>
+        <table>
+          <tr>
+            <th>Name</th>
+            <th>Group</th>
+            <th>Area</th>
+            <th>Dates</th>
           </tr>
-          <% end %>
-      <% end %>
-      </table>
 
+          <% leg_mems.group_by { |m| m['person'] }.sort_by { |p, _| p['name'] }.each do |p, mems| %>
+            <tr id="mem-<%= p['id'].split('/').last %>">
+              <td rowspan="<%= mems.count %>"><%= p['name'] %></td>
+              <% mems.each do |m| %>
+                <td><%= m['on_behalf_of']['name'] %></td>
+                <td><%= m['organization']['name'] %></td>
+                <td><%= m['area'] && m['area']['name'] %></td>
+                <td> 
+                  <% if m['start_date'].to_s != @term['start_date'].to_s or m['end_date'].to_s != @term['end_date'].to_s %>
+                    <p><%= m['start_date'] %>–<%= m['end_date'] %></p>
+                  <% end %>
+                </td>
+              </tr>
+            <% end %>
+          <% end %>
+        </table>
+      <% end %>
     <% end %>
-    </div>
+  </div>
 </div>

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -52,7 +52,6 @@
               <td rowspan="<%= mems.count %>"><%= p['name'] %></td>
               <% mems.each do |m| %>
                 <td><%= m['on_behalf_of']['name'] %></td>
-                <td><%= m['organization']['name'] %></td>
                 <td><%= m['area'] && m['area']['name'] %></td>
                 <td> 
                   <% if m['start_date'].to_s != @term['start_date'].to_s or m['end_date'].to_s != @term['end_date'].to_s %>

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -37,8 +37,9 @@
       <h2>Members</h3>
 
       <% @memberships.group_by { |m| m['organization'] }.each do |leg, leg_mems| %>
-        <h3><%= leg['name'] %></h3>
-        <table>
+        <% if @memberships.find { |m| m['organization']['id'] != leg['id'] } %><h3><%= leg['name'] %></h3><% end %>
+        
+        <table id="house-<%= leg['id'].split('/').last %>">
           <tr>
             <th>Name</th>
             <th>Group</th>


### PR DESCRIPTION
Show a separate table for each House, where appropriate:

![split houses 2015-04-28 at 07 23 43](https://cloud.githubusercontent.com/assets/57483/7363915/30e7b8f6-ed78-11e4-8d8c-81e40da1521c.png)

Closes #97 

The party groupings at the top are still a combination of both. It’ll be easy to split those similarly, but it might be useful in some cases to view the totals as well. Needs a little more thought as to the best way to show that… #113