### PR TITLE
Improve layout of "Term Table" page

### DIFF
--- a/public/javascript/main.js
+++ b/public/javascript/main.js
@@ -1,0 +1,76 @@
+(function ($) {
+
+  $.fn.fixedThead = function() {
+
+    // Call this on a <thead> element and it'll stay attached
+    // to the top of the window when you scroll down.
+
+    var calculateCloneDimensions = function calculateCloneDimensions($originalThead, $cloneThead){
+      $cloneThead.css({
+        width: $originalThead.outerWidth()
+      });
+
+      $('tr', $originalThead).each(function(tr_index, tr){
+        $('th', tr).each(function(th_index, th){
+          $cloneThead.find('tr:eq(' + tr_index + ') th:eq(' + th_index + ')').css({
+            width: $(th).outerWidth()
+          });
+        });
+      });
+    }
+
+    var showOrHideClone = function showOrHideClone($table, $cloneThead){
+      var bounds = $table[0].getBoundingClientRect();
+
+      // First we detect whether *any* of the table is visible,
+      // then, if it is, we position the fixed thead so that it
+      // never extends outside of the table bounds even when the
+      // visible portion of the table is shorter than the thead.
+
+      if(bounds.top <= 0 && bounds.bottom >= 0){
+        $cloneThead.show();
+
+        var rowHeight = $cloneThead.outerHeight();
+        if(bounds.bottom < rowHeight){
+          $cloneThead.css({
+            top: (rowHeight - bounds.bottom) * -1
+          });
+        } else {
+          $cloneThead.css({
+            top: 0
+          });
+        }
+
+      } else {
+        $cloneThead.hide();
+      }
+    }
+
+    return this.each(function() {
+      var $originalThead = $(this);
+      var $table = $originalThead.parent('table');
+      var $cloneThead = $originalThead.clone().removeClass('js-fixed-thead').addClass('js-fixed-thead__clone');
+
+      $cloneThead.insertAfter($originalThead);
+      $cloneThead.hide();
+
+      calculateCloneDimensions($originalThead, $cloneThead);
+      showOrHideClone($table, $cloneThead);
+
+      $(window).resize(function(){
+        calculateCloneDimensions($originalThead, $cloneThead);
+        showOrHideClone($table, $cloneThead);
+      });
+
+      $(window).scroll(function(){
+        showOrHideClone($table, $cloneThead);
+      });
+    });
+
+  };
+
+}(jQuery));
+
+$(function(){
+  $('.js-fixed-thead').fixedThead();
+});

--- a/t/web/term_table.rb
+++ b/t/web/term_table.rb
@@ -50,28 +50,28 @@ describe "Per Country Tests" do
     end
 
     it "should list the parties" do
-      subject.css('#term table').text.must_include 'Finnish Centre Party'
+      subject.css('.term-membership-table').text.must_include 'Finnish Centre Party'
     end
 
     it "should list the areas" do
-      subject.css('#term table').text.must_include 'Oulun'
+      subject.css('.term-membership-table').text.must_include 'Oulun'
     end
 
     it "shouldn't show any dates for Mikko Kuoppa" do
-      subject.css('tr#mem-444').text.wont_include '20'
+      subject.css('.term-membership-table tr#mem-444').text.wont_include '20'
     end
 
     it "should show early departure date for Matti Vanhanen" do
-      subject.css('tr#mem-414 td:last').text.must_include '2010-09-19'
+      subject.css('.term-membership-table tr#mem-414 td:last').text.must_include '2010-09-19'
     end
 
     it "should show late start date for Risto Kuisma" do
-      subject.css('tr#mem-473 td:last').text.must_include '2010-07-13'
+      subject.css('.term-membership-table tr#mem-473 td:last').text.must_include '2010-07-13'
     end
 
     it "should have two rows for Merikukka Forsius" do
       # Changed Party mid-term, so one entry per party
-      subject.at_css('tr#mem-560 td:first').attr('rowspan').to_i.must_equal 2
+      subject.at_css('.term-membership-table tr#mem-560 td:first').attr('rowspan').to_i.must_equal 2
     end
 
     it "should link to 34" do
@@ -86,8 +86,8 @@ describe "Per Country Tests" do
       subject.css('a[href*="/term_table/33"]').count.must_equal 0
     end
 
-    it "shouldn't have a heading for the house name" do
-      subject.css('h3').text.downcase.wont_include 'eduskunta'
+    it "shouldn't have a button for the house name" do
+      subject.css('a.button').text.downcase.wont_include 'eduskunta'
     end
 
 
@@ -105,8 +105,8 @@ describe "Per Country Tests" do
       subject.at_css('#house-senate tr#mem-GB6 td:first').text.must_include 'Jacinta Collins'
     end
 
-    it "should have a heading for the house name" do
-      subject.css('h3').text.downcase.must_include 'senate'
+    it "should have a button with the house name" do
+      subject.css('a.button').text.downcase.must_include 'senate'
     end
 
   end

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -11,6 +11,7 @@
     <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     <script src="http://code.jquery.com/jquery-latest.js"></script>
+    <script src="/javascript/main.js"></script>
     <title>PopIt Viewer</title>
 </head>
 <body>

--- a/views/sass/_components.scss
+++ b/views/sass/_components.scss
@@ -325,3 +325,9 @@ p.lead {
         opacity: 0.5;
     }
 }
+
+.js-fixed-thead__clone {
+  position: fixed;
+  top: 0;
+  background-color: #fff;
+}

--- a/views/sass/_components.scss
+++ b/views/sass/_components.scss
@@ -56,37 +56,42 @@ p.lead {
 .button {
     background-color: $colour_green;
     border-radius: $border_radius;
-    border: 0;
+    border: 1px solid $colour_green;
     color: $colour_white;
     display: inline-block;
     font-weight: $body_typeface_bold;
     padding: 0.75em 1.5em;
-    @include vendor-prefix(transition, background-color $animation-short);
+    @include vendor-prefix(transition, all $animation-short);
     &:hover,
     &:active,
     &:focus {
         background-color: darken($colour_green, 5%);
+        border-color: darken($colour_green, 5%);
         color: $colour_white;
-        @include vendor-prefix(transition, background-color $animation-short);
+        @include vendor-prefix(transition, all $animation-short);
     }
 }
 
 .button--secondary {
     background-color: $colour_red;
+    border-color: $colour_red;
     &:hover,
     &:active,
     &:focus {
         background-color: darken($colour_red, 5%);
+        border-color: darken($colour_red, 5%);
     }
 }
 
 .button--tertiary {
     background-color: $colour_light_grey;
+    border-color: $colour_light_grey;
     color: $colour_dark_grey;
     &:hover,
     &:active,
     &:focus {
         background-color: darken($colour_light_grey, 5%);
+        border-color: darken($colour_light_grey, 5%);
         color: $colour_black;
     }
 }
@@ -95,11 +100,12 @@ p.lead {
     background: transparent;
     color: $colour_dark_grey;
     font-weight: normal;
-    border: 1px solid rgba(0,0,0,0.1);
+    border-color: rgba(0,0,0,0.1);
     &:hover,
     &:active,
     &:focus {
         background-color: rgba(0,0,0,0.1);
+        border-color: rgba(0,0,0,0.1);
         color: $colour_dark_grey;
     }
 }

--- a/views/sass/_components.scss
+++ b/views/sass/_components.scss
@@ -170,11 +170,21 @@ p.lead {
     @media ( min-width: $medium_screen) {
         padding: 4em 0;
     }
+
+    & > .container {
+      & > :first-child {
+        margin-top: 0;
+      }
+
+      & > :last-child {
+        margin-bottom: 0;
+      }
+    }
 }
 
 .page-section--grey {
     background-color: $colour_off_white;
-    
+
     pre {
         background-color: #fff;
     }
@@ -258,7 +268,7 @@ p.lead {
     @include flex-align(center);
     @include flex-wrap(wrap);
     @extend .unstyled-list;
-  
+
     & > * {
         @include flex(0 0 100%);
 
@@ -302,15 +312,15 @@ p.lead {
             text-shadow: 0 1px 0 rgba(0,0,0,0.2);
         }
     }
-    
+
     h3 {
         font-weight: 500;
-        
+
         & + p {
             margin-bottom: 0.2em;
         }
     }
-    
+
     p {
         opacity: 0.5;
     }

--- a/views/sass/_custom.scss
+++ b/views/sass/_custom.scss
@@ -1,0 +1,12 @@
+.term-membership-table {
+  .button-group {
+    margin-bottom: 1em;
+  }
+
+  // Make the selected tab look unclickable
+  .button--primary {
+    cursor: default;
+    background-color: $colour_green;
+    border-color: $colour_green;
+  }
+}

--- a/views/sass/main.scss
+++ b/views/sass/main.scss
@@ -33,3 +33,5 @@ body {
 @import 'components';
 @import 'site-header';
 @import 'site-footer';
+
+@import 'custom';

--- a/views/styling.erb
+++ b/views/styling.erb
@@ -20,6 +20,7 @@
                     <li><a href="#avatar-units">Avatar units</a></li>
                     <li><a href="#basic-lists">Unstyled and inline lists</a></li>
                     <li><a href="#alerts">Alerts</a></li>
+                    <li><a href="#tables">Fixed table headers</a></li>
                 </ul>
             </div>
 
@@ -217,6 +218,29 @@
                 <div class="alert alert--error">
                     <p><strong>Something went wrong.</strong> Try reloading your browser.</p>
                 </div>
+
+                <hr>
+
+                <h1 id="tables">Fixed table headers</h1>
+
+                <p>If you have a very long table, add a class of <code>js-fixed-thead</code> to the <code>&lt;thead&gt;</code> element, and it will automatically stick to the top of the window when the user scrolls down the page.</p>
+
+                <pre>
+&lt;table&gt;
+  &lt;thead class="js-fixed-thead"&gt;
+      &lt;tr&gt;
+          &lt;th&gt;Name&lt;/th&gt;
+          &lt;th&gt;Group&lt;/th&gt;
+          &lt;th&gt;Area&lt;/th&gt;
+      &lt;/tr&gt;
+  &lt;/thead&gt;
+  &lt;tr&gt;
+    …
+  &lt;/tr&gt;
+  &lt;tr&gt;
+    …
+  &lt;/tr&gt;
+&lt;/table&gt;</pre>
 
             </div>
         </div>

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -1,68 +1,89 @@
 <div class="page-section" id="term">
-  <div class="container">
-    <h1 class="text-center"><span class="avatar"><i class="fa fa-university"></i></span> <%= @term['name'] %></h1>
-    <% unless @term['start_date'].to_s.empty? and @term['end_date'].to_s.empty? %>
-      <p class="text-center"><%= @term['start_date'] %> – <%= @term['end_date'] %></p>
-    <% end %>
-
-    <p>
-    <% if @prev_term %>
-      <span><a href="<%= term_table_url(@prev_term) %>">
-        <i class="fa fa-arrow-left"></i> <%= @prev_term['name'] %>
-      </a></span>
-    <% end %>
-
-    <% if @next_term %>
-      <span style="float:right"><a href="<%= term_table_url(@next_term) %>">
-          <%= @next_term['name'] %> <i class="fa fa-arrow-right"></i>
-      </a></span>
-    <% end %>
-    </p>
-
-    <% if @memberships.count.zero? %>
-      
-    <% else %>
-      <h2>Party Groupings</h2>
-
-      <ul class="grid-list">
-        <% @memberships.group_by { |m| m['on_behalf_of'] }.sort_by { |p, ms| ms.count }.reverse.each do |party, mems| %>
-          <li><div class="avatar-unit">
-            <span class="avatar"><i class="fa fa-users"></i></span>
-            <h3><%= party['name'] %></h3>
-            <p><%= mems.count %> seat<% if mems.count > 1 %>s<% end %></p>
-          </div></li>
-        <% end %>
-      </ul>
-
-      <h2>Members</h3>
-
-      <% @memberships.group_by { |m| m['organization'] }.each do |leg, leg_mems| %>
-        <% if @memberships.find { |m| m['organization']['id'] != leg['id'] } %><h3><%= leg['name'] %></h3><% end %>
-        
-        <table id="house-<%= leg['id'].split('/').last %>">
-          <tr>
-            <th>Name</th>
-            <th>Group</th>
-            <th>Area</th>
-            <th>Dates</th>
-          </tr>
-
-          <% leg_mems.group_by { |m| m['person'] }.sort_by { |p, _| p['name'] }.each do |p, mems| %>
-            <tr id="mem-<%= p['id'].split('/').last %>">
-              <td rowspan="<%= mems.count %>"><%= p['name'] %></td>
-              <% mems.each do |m| %>
-                <td><%= m['on_behalf_of']['name'] %></td>
-                <td><%= m['area'] && m['area']['name'] %></td>
-                <td> 
-                  <% if m['start_date'].to_s != @term['start_date'].to_s or m['end_date'].to_s != @term['end_date'].to_s %>
-                    <p><%= m['start_date'] %>–<%= m['end_date'] %></p>
-                  <% end %>
-                </td>
-              </tr>
-            <% end %>
-          <% end %>
-        </table>
+    <div class="container">
+        <h1 class="text-center"><span class="avatar"><i class="fa fa-university"></i></span> <%= @term['name'] %></h1>
+      <% unless @term['start_date'].to_s.empty? and @term['end_date'].to_s.empty? %>
+        <p class="text-center"><%= @term['start_date'] %> – <%= @term['end_date'] or 'current' %></p>
       <% end %>
-    <% end %>
-  </div>
+
+      <% if @prev_term or @next_term %>
+        <p>
+          <% if @prev_term %>
+            <a href="<%= term_table_url(@prev_term) %>">
+                <i class="fa fa-arrow-left"></i>
+                <%= @prev_term['name'] %>
+            </a>
+          <% end %>
+
+          <% if @next_term %>
+            <a href="<%= term_table_url(@next_term) %>" style="float:right">
+                <%= @next_term['name'] %>
+                <i class="fa fa-arrow-right"></i>
+            </a>
+          <% end %>
+        </p>
+      <% end %>
+    </div>
 </div>
+
+<% if @memberships.count.zero? %>
+
+<% else %>
+
+    <div class="page-section page-section--grey">
+        <div class="container">
+            <h2 class="text-center">Party Groupings</h2>
+
+            <ul class="grid-list">
+              <% @memberships.group_by { |m| m['on_behalf_of'] }.sort_by { |p, ms| ms.count }.reverse.each do |party, mems| %>
+                <li><div class="avatar-unit">
+                    <span class="avatar"><i class="fa fa-users"></i></span>
+                    <h3><%= party['name'] %></h3>
+                    <p><%= mems.count %> seat<% if mems.count > 1 %>s<% end %></p>
+                </div></li>
+              <% end %>
+            </ul>
+        </div>
+    </div>
+
+    <div class="page-section page-section">
+        <div class="container">
+            <h2 class="text-center">Members</h3>
+
+          <% @memberships.group_by { |m| m['organization'] }.each do |leg, leg_mems| %>
+              <% if @memberships.find { |m| m['organization']['id'] != leg['id'] } %>
+                <h3 class="text-center"><%= leg['name'] %></h3>
+              <% end %>
+
+            <table id="house-<%= leg['id'].split('/').last %>">
+                <tr>
+                    <th>Name</th>
+                    <th>Group</th>
+                    <th>Area</th>
+                    <th>Dates</th>
+                </tr>
+
+              <% leg_mems.group_by { |m| m['person'] }.sort_by { |p, _| p['name'] }.each do |p, mems| %>
+                  <%# Each person can have multiple party affiliations in a single term, so we
+                      loop through them and set the first cell (their name) to span all the rows %>
+                  <% mems.each_with_index do |m, i| %>
+                    <tr id="mem-<%= p['id'].split('/').last %>">
+                      <% if i == 0 %>
+                        <td rowspan="<%= mems.count %>"><%= p['name'] %></td>
+                      <% end %>
+                        <td><%= m['on_behalf_of']['name'] %></td>
+                        <td><%= m['area'] && m['area']['name'] %></td>
+                        <td>
+                          <% if m['start_date'].to_s != @term['start_date'].to_s or m['end_date'].to_s != @term['end_date'].to_s %>
+                            <%= m['start_date'] %>–<%= m['end_date'] or 'current' %>
+                          <% end %>
+                        </td>
+                    </tr>
+                  <% end %>
+              <% end %>
+
+            </table>
+          <% end %>
+        </div>
+    </div>
+
+<% end %>

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -55,12 +55,14 @@
               <% end %>
 
             <table id="house-<%= leg['id'].split('/').last %>">
-                <tr>
-                    <th>Name</th>
-                    <th>Group</th>
-                    <th>Area</th>
-                    <th>Dates</th>
-                </tr>
+                <thead class="js-fixed-thead">
+                    <tr>
+                        <th>Name</th>
+                        <th>Group</th>
+                        <th>Area</th>
+                        <th>Dates</th>
+                    </tr>
+                </thead>
 
               <% leg_mems.group_by { |m| m['person'] }.sort_by { |p, _| p['name'] }.each do |p, mems| %>
                   <%# Each person can have multiple party affiliations in a single term, so we

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -50,12 +50,25 @@
             <h2 class="text-center">Members</h3>
 
           <% @memberships.group_by { |m| m['organization'] }.each do |leg, leg_mems| %>
-              <% if @memberships.find { |m| m['organization']['id'] != leg['id'] } %>
-                <h3 class="text-center"><%= leg['name'] %></h3>
-              <% end %>
-
-            <table id="house-<%= leg['id'].split('/').last %>">
+            <table class="term-membership-table" id="house-<%= leg['id'].split('/').last %>">
                 <thead class="js-fixed-thead">
+
+                  <% if @memberships.group_by { |m| m['organization'] }.length > 1 %>
+                    <tr>
+                        <td colspan="4" class="text-center">
+                            <div class="button-group">
+                              <% @memberships.group_by { |m| m['organization'] }.each do |leg2, leg_mems2| %>
+                                  <% if leg2['id'] == leg['id'] %>
+                                    <a class="button button--primary" href="#house-<%= leg2['id'].split('/').last %>"><%= leg2['name'] %></a>
+                                  <% else %>
+                                    <a class="button button--quarternary" href="#house-<%= leg2['id'].split('/').last %>"><%= leg2['name'] %></a>
+                                  <% end %>
+                              <% end %>
+                            </div>
+                        </td>
+                    </tr>
+                  <% end %>
+
                     <tr>
                         <th>Name</th>
                         <th>Group</th>


### PR DESCRIPTION
Part of #96.

Includes visual distinction between parties and members, buttons to jump between bicameral chambers and fixed table headers when you scroll down the list of members.

![screen shot 2015-04-30 at 14 24 28](https://cloud.githubusercontent.com/assets/739624/7413572/ce5a2218-ef44-11e4-826b-1a342befcf22.png)
