### PR TITLE
Remove empty dates column

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -58,13 +58,15 @@ get '/:country/term/:id' do |country, id|
 end
 
 get '/:country/term_table/?:id?.html' do |country, id|
-  @country = country
   @term = id ? @popolo.term_from_id(id) :  @popolo.current_term
   pass unless @term
+
+  @country = country
   @page_title = @term['name']
   @terms = @popolo.term_list
   (@prev_term, _, @next_term) = [nil, @terms, nil].flatten.each_cons(3).find { |p, e, n| e['id'] == @term['id'] }
   @memberships = @popolo.term_memberships(@term)
+  @houses = @memberships.map { |m| m['organization'] }.uniq
   @csv_url = "/#{country}/term_table/#{@term['id'].split('/').last}.csv"
   erb :term_table
 end

--- a/app.rb
+++ b/app.rb
@@ -73,24 +73,9 @@ get '/:country/term_table/?:id?.csv' do |country, id|
   @term = id ? @popolo.term_from_id(id) :  @popolo.current_term
   pass unless @term
 
-  @terms = @popolo.term_list
-  @memberships = @popolo.term_memberships(@term)
-
-  header = %w(id name group area start_date end_date).to_csv
-  rows = @memberships.sort_by { |m| [m['person']['name'], m['start_date']] }.map do |m|
-    { 
-      id: m['person']['id'].split('/').last,
-      name: m['person']['name'],
-      group: m['on_behalf_of']['name'],
-      area: m['area'] && m['area']['name'],
-      start_date: m['start_date'],
-      end_date: m['end_date']
-    }.values.to_csv
-  end
-
   content_type 'application/csv'
   attachment   "everypolitician-#{country}-#{@term['id'].split('/').last}.csv"
-  [header, rows].compact.join
+  @popolo.term_as_csv(@term)
 end
 
 get '/:country/person/:id' do |country, id|

--- a/lib/popolo_helper.rb
+++ b/lib/popolo_helper.rb
@@ -106,6 +106,24 @@ module Popolo
       legislative_memberships.find_all { |m| m.has_key?('area') && m['area']['name'] == name }
     end
 
+    require 'csv'
+    def term_as_csv(t)
+      memberships = term_memberships(t)
+
+      header = %w(id name group area start_date end_date).to_csv
+      rows = memberships.sort_by { |m| [m['person']['name'], m['start_date']] }.map do |m|
+        { 
+          id: m['person']['id'].split('/').last,
+          name: m['person']['name'],
+          group: m['on_behalf_of']['name'],
+          area: m['area'] && m['area']['name'],
+          start_date: m['start_date'],
+          end_date: m['end_date']
+        }.values.to_csv
+      end 
+      [header, rows].compact.join
+    end 
+
   end
 
   module Helper

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -79,7 +79,7 @@
                         <th>Name</th>
                         <th>Group</th>
                         <th>Area</th>
-                        <th>Dates</th>
+                        <% if leg_mems.any? { |m| m['start_date'].to_s != @term['start_date'].to_s or m['end_date'].to_s != @term['end_date'].to_s } %><th>Dates</th><% end %>
                     </tr>
                 </thead>
 
@@ -93,11 +93,11 @@
                       <% end %>
                         <td><%= m['on_behalf_of']['name'] %></td>
                         <td><%= m['area'] && m['area']['name'] %></td>
-                        <td>
+                      <% if leg_mems.any? { |m| m['start_date'].to_s != @term['start_date'].to_s or m['end_date'].to_s != @term['end_date'].to_s }%>  <td>
                           <% if m['start_date'].to_s != @term['start_date'].to_s or m['end_date'].to_s != @term['end_date'].to_s %>
                             <%= m['start_date'] %>–<%= m['end_date'] %>
                           <% end %>
-                        </td>
+                        </td><% end %>
                     </tr>
                   <% end %>
               <% end %>

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -61,13 +61,13 @@
                                 <span class="large-screen-only">CSV</span>
                               </a>
                             </div>
-                          <% if @memberships.group_by { |m| m['organization'] }.length > 1 %>
+                          <% if @houses.count > 1 %>
                             <div class="button-group">
-                              <% @memberships.group_by { |m| m['organization'] }.each do |leg2, leg_mems2| %>
-                                  <% if leg2['id'] == leg['id'] %>
-                                    <a class="button button--primary" href="#house-<%= leg2['id'].split('/').last %>"><%= leg2['name'] %></a>
+                              <% @houses.each do |h| %>
+                                  <% if h['id'] == leg['id'] %>
+                                    <a class="button button--primary" href="#house-<%= h['id'].split('/').last %>"><%= h['name'] %></a>
                                   <% else %>
-                                    <a class="button button--quarternary" href="#house-<%= leg2['id'].split('/').last %>"><%= leg2['name'] %></a>
+                                    <a class="button button--quarternary" href="#house-<%= h['id'].split('/').last %>"><%= h['name'] %></a>
                                   <% end %>
                               <% end %>
                             </div>

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -95,7 +95,7 @@
                         <td><%= m['area'] && m['area']['name'] %></td>
                         <td>
                           <% if m['start_date'].to_s != @term['start_date'].to_s or m['end_date'].to_s != @term['end_date'].to_s %>
-                            <%= m['start_date'] %>–<%= m['end_date'] or 'current' %>
+                            <%= m['start_date'] %>–<%= m['end_date'] %>
                           <% end %>
                         </td>
                     </tr>

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -47,7 +47,7 @@
 
     <div class="page-section page-section">
         <div class="container">
-            <h2 class="text-center">Members</h3>
+            <h2 class="text-center">Members</h2>
 
           <% @memberships.group_by { |m| m['organization'] }.each do |leg, leg_mems| %>
             <table class="term-membership-table <% unless @country == 'finland' %>js-sortable<% end %>" id="house-<%= leg['id'].split('/').last %>">


### PR DESCRIPTION
Only display a dates column when at least one Membership has start or
end dates different from the Term itself