### PR TITLE
Add webkit-flex-wrap for Safari

### DIFF
--- a/views/sass/_mixins.scss
+++ b/views/sass/_mixins.scss
@@ -61,6 +61,7 @@
 @mixin flex-wrap($wrap) {
   -moz-box-wrap: $wrap;
   -webkit-box-wrap: $wrap;
+  -webkit-flex-wrap: $wrap;
   -ms-flexbox-wrap: $wrap;
   flex-wrap: $wrap;
 }


### PR DESCRIPTION
Add css rule to fix flexbox wrapping in Safari (thanks @dracos)

Fixes #127

Before:
![flexnowrap at 13 24 36](https://cloud.githubusercontent.com/assets/57483/7554241/00226438-f718-11e4-94a4-2e783f290be3.png)

After:
![flexwrap at 13 24 43](https://cloud.githubusercontent.com/assets/57483/7554244/11b991bc-f718-11e4-9c9e-62a8f5f07ea7.png)
