### PR TITLE
Include 'chamber' column in CSV output

### DIFF
--- a/lib/popolo_helper.rb
+++ b/lib/popolo_helper.rb
@@ -110,13 +110,14 @@ module Popolo
     def term_as_csv(t)
       memberships = term_memberships(t)
 
-      header = %w(id name group area start_date end_date).to_csv
+      header = %w(id name group area chamber start_date end_date).to_csv
       rows = memberships.sort_by { |m| [m['person']['name'], m['start_date']] }.map do |m|
         { 
           id: m['person']['id'].split('/').last,
           name: m['person']['name'],
           group: m['on_behalf_of']['name'],
           area: m['area'] && m['area']['name'],
+          chamber: m['organization']['name'],
           start_date: m['start_date'],
           end_date: m['end_date']
         }.values.to_csv

--- a/t/data/term_table.rb
+++ b/t/data/term_table.rb
@@ -31,6 +31,7 @@ describe "Basic loads" do
       last_response.header['Content-Disposition'].must_include country
       data = CSV.parse(last_response.body, headers: true)
       data.first.headers.must_include 'group'
+      data.first.headers.must_include 'chamber'
       data.count.must_be :>, 1
     end
 

--- a/t/data/term_table.rb
+++ b/t/data/term_table.rb
@@ -39,3 +39,30 @@ describe "Basic loads" do
 
 end
 
+
+describe "Per Country Tests" do
+
+  it "Finland" do
+
+    get('/finland/term_table/35.csv')
+
+    data = CSV.parse(last_response.body, headers: true)
+    chamber_index = data.headers.find_index('chamber')
+    chambers = data.map { |row| row[chamber_index] }.uniq
+    chambers.count.must_equal 1
+    chambers.must_include 'Eduskunta'
+  end
+
+  it "Australia" do
+
+    get('/australia/term_table.csv')
+
+    data = CSV.parse(last_response.body, headers: true)
+    chamber_index = data.headers.find_index('chamber')
+    chambers = data.map { |row| row[chamber_index] }.uniq
+    chambers.count.must_equal 2
+    chambers.must_include "House of Representatives"
+    chambers.must_include "Senate"
+  end
+
+end

--- a/t/data/term_table.rb
+++ b/t/data/term_table.rb
@@ -42,24 +42,23 @@ end
 
 describe "Per Country Tests" do
 
-  it "Finland" do
+  it "should have one chamber for Finland" do
 
     get('/finland/term_table/35.csv')
 
     data = CSV.parse(last_response.body, headers: true)
-    chamber_index = data.headers.find_index('chamber')
-    chambers = data.map { |row| row[chamber_index] }.uniq
+    chambers = data.map { |row| row['chamber'] }.uniq
     chambers.count.must_equal 1
     chambers.must_include 'Eduskunta'
   end
 
-  it "Australia" do
+  it "should have two chambers for Australia" do
 
     get('/australia/term_table.csv')
 
     data = CSV.parse(last_response.body, headers: true)
     chamber_index = data.headers.find_index('chamber')
-    chambers = data.map { |row| row[chamber_index] }.uniq
+    chambers = data.map { |row| row['chamber'] }.uniq
     chambers.count.must_equal 2
     chambers.must_include "House of Representatives"
     chambers.must_include "Senate"


### PR DESCRIPTION
The CSV output for a term now includes a column containing the chamber.

Fixes #145 