### PR TITLE
Fix the sort-order of Parties

### DIFF
--- a/t/web/term_table.rb
+++ b/t/web/term_table.rb
@@ -123,5 +123,18 @@ describe "Per Country Tests" do
 
   end
 
+  describe "Canada" do
+
+    before { get '/canada/term_table.html' }
+
+    it "should have three parties with 2 seats" do
+      doubles = subject.xpath('//div[@class="avatar-unit"]')
+      doubles = subject.xpath('//p[contains(.,"2 seats")]/../h3').map { |p| p.text }
+      doubles.count.must_equal 3
+      doubles.first.must_equal 'Bloc Québécois'
+      doubles.last.must_equal 'Green Party'
+    end
+  end
+
 end
 

--- a/views/term_table.erb
+++ b/views/term_table.erb
@@ -34,7 +34,7 @@
             <h2 class="text-center">Party Groupings</h2>
 
             <ul class="grid-list">
-              <% @memberships.group_by { |m| m['on_behalf_of'] }.sort_by { |p, ms| ms.count }.reverse.each do |party, mems| %>
+              <% @memberships.group_by { |m| m['on_behalf_of'] }.sort_by { |p, ms| [-ms.count, p['name']] }.each do |party, mems| %>
                 <li><div class="avatar-unit">
                     <span class="avatar"><i class="fa fa-users"></i></span>
                     <h3><%= party['name'].to_s.empty? ? 'Independent' : party['name'] %></h3>


### PR DESCRIPTION
Sorting only by the number of seats they have leads to inconsistent
returns (and thus needless HTML changes to eyeball in diffs). If
membership numbers are the same, order by name.